### PR TITLE
Add warning for Roborock Q10 Series

### DIFF
--- a/README_SUPPORTED.md
+++ b/README_SUPPORTED.md
@@ -12,6 +12,19 @@ These devices have been fully tested and are confirmed to work as expected.
 
 ---
 
+## ⚠️ Not Supported Devices
+
+This plugin does NOT support these models:
+
+| Device Name                | Model String                  |
+|----------------------------|-------------------------------|
+| Roborock Q10 Series        | `roborock.vacuum.ss07`        |
+
+**Reason:**
+Roborock recently released a new series of models, Q10. Roborock has changed the protocol for how these devices interact.
+
+---
+
 ## ⚠️ Other Supported Devices
 
 All other models listed in the code are supported, but **may have some limitations**.


### PR DESCRIPTION
Add warning for Roborock Q10 Series.

I tested it and it doesn't work at the moment:

```
debug [16:14:26.882] [Matterbridge Roborock Vacuum Plugin] MatterbridgePlatform for plugin matterbridge-roborock-vacuum-plugin is fully initialized
debug [16:14:26.884] [Matterbridge Roborock Vacuum Plugin] Saving 0 selectDevice...
debug [16:14:26.895] [Matterbridge Roborock Vacuum Plugin] Saving 0 selectEntity...
debug [16:14:27.565] [Matterbridge Roborock Vacuum Plugin] Initializing - userData: { uid: 8747***, tokentype: '', token: '*****', rruid: '*******', region: 'eu', countrycode: '33', country: 'FR', nickname: '*****', rriot: { u: '******', s: 'lNSp9M', h: 'cHy11EZXvM', k: 'rBUZyeTf', r: { r: 'EU', a: 'https://api-eu.roborock.com', m: 'ssl://mqtt-eu-2.roborock.com:8883', l: 'https://wood-eu.roborock.com' } }, tuyaDeviceState: 0, avatarurl: 'https://files.roborock.com/iottest/default_avatar.png' }
notice [16:14:27.904] [Matterbridge Roborock Vacuum Plugin] Initializing - devices: [ ]
error [16:14:27.905] [Matterbridge Roborock Vacuum Plugin] Initializing: No device found
```

So no device is found.