### PR TITLE
Use getHomev3 to discover new models

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ To get the **DUID** for your devices, you have two options:
 
 - **Under active development**
 - Requires **`matterbridge@3.1.3`**
-- ⚠️ **Known Issue:** Vacuum may appear as **two devices** in Apple Home
+- ⚠️ **Known Issue:** 
++ Vacuum may appear as **two devices** in Apple Home
++ Error: Wrong CRC32 2241274590, expected 0 -> this is normal error and not impact to plugin functionality
++ 
 
 ---
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -8,7 +8,7 @@ Follow these steps to add support for a new device:
 
 ## 1. Check the Model
 
-- Open [`src/roborock/features/DeviceModel.ts`](src/roborock/features/DeviceModel.ts).
+- Open [`src/roborockCommunication/Zmodel/deviceModel.ts`](src/roborockCommunication/Zmodel/deviceModel.ts).
 - If your model does not exist, **create a new entry** for it.
 
 ---
@@ -17,21 +17,27 @@ Follow these steps to add support for a new device:
 
 - Create a new folder under [`src/behaviors/roborock.vacuum`](src/behaviors/roborock.vacuum) named after the market name of your vacuum.
 - Inside this folder:
-  - **Create a `model.ts` file**  
-    _Example:_ [`src/behaviors/roborock.vacuum/QREVO_EDGE_5V1/a187.ts`](src/behaviors/roborock.vacuum/QREVO_EDGE_5V1/a187.ts)  
-    This file handles sending requests to control your vacuum (start, pause, resume, go home, etc.).
-  - **Create an `initalData.ts` file**  
-    This file defines functions that return initial data for your device.
+  - **Create a `initalData.ts` file**  
+    _Example:_ [`src/behaviors/roborock.vacuum/smart/initalData.ts`](src/behaviors/roborock.vacuum/smart/initalData.ts)
+    This file defines functions that return initial data for your device. (You can inherit from default or create your own)
+  - **Create an `runtimes.ts` file**  
+  _Example:_ [`src/behaviors/roborock.vacuum/smart/runtimes.ts`](src/behaviors/roborock.vacuum/smart/runtimes.ts)
+    In case you define your own initial data. Create new method that override the default method.
+  - **Create an `abcyxz.ts` file**  
+  _Example:_ [`src/behaviors/roborock.vacuum/smart/smart.ts`](src/behaviors/roborock.vacuum/smart/smart.ts)
+    Define matterbridge command handler logic to sending requests to control your vacuum (start, pause, resume, go home, etc.).
+    (Use in step 4)
 
 ---
 
 ## 3. Register Your Initial Functions
 
 - Add your initial functions to the following files:
-  - [`src/initialData/getOperationalStates.ts`](src/initialData/getOperationalStates.ts)
   - [`src/initialData/getSupportedCleanModes.ts`](src/initialData/getSupportedCleanModes.ts)
   - [`src/initialData/getSupportedRunModes.ts`](src/initialData/getSupportedRunModes.ts)
+  - [`src/initialData/getOperationalStates.ts`](src/initialData/getOperationalStates.ts)
 
+***_In somecase, you may need to update whole function to support switch case_***
 ---
 
 ## 4. Update the Behavior Factory

--- a/src/roborockCommunication/RESTAPI/roborockIoTApi.ts
+++ b/src/roborockCommunication/RESTAPI/roborockIoTApi.ts
@@ -57,6 +57,18 @@ export class RoborockIoTApi {
     }
   }
 
+  public async getHomev3(homeId: number): Promise<Home | undefined> {
+    const result = await this.api.get('v3/user/homes/' + homeId);
+
+    const apiResponse: ApiResponse<Home> = result.data;
+    if (apiResponse.result) {
+      return apiResponse.result;
+    } else {
+      this.logger.error('Failed to retrieve the home data');
+      return undefined;
+    }
+  }
+  
   public async getScenes(homeId: number): Promise<Scene[] | undefined> {
     const result = await this.api.get('user/scene/home/' + homeId);
 

--- a/src/roborockCommunication/RESTAPI/roborockIoTApi.ts
+++ b/src/roborockCommunication/RESTAPI/roborockIoTApi.ts
@@ -68,7 +68,7 @@ export class RoborockIoTApi {
       return undefined;
     }
   }
-  
+
   public async getScenes(homeId: number): Promise<Scene[] | undefined> {
     const result = await this.api.get('user/scene/home/' + homeId);
 

--- a/src/roborockService.ts
+++ b/src/roborockService.ts
@@ -303,7 +303,7 @@ export default class RoborockService {
     assert(this.iotApi !== undefined);
     assert(this.userdata !== undefined);
 
-    const homeData = await this.iotApi.getHomev2(homeid);
+    const homeData = await this.iotApi.getHomev3(homeid);
 
     if (!homeData) {
       throw new Error('Failed to retrieve the home data');


### PR DESCRIPTION
Use getHomev3 to discover new models like Roborock Q10 S5+.
I looked at the exchanges between the application and the API. I see that it uses this version of the API: https://api-eu.roborock.com/v3/user/homes/1234567