### PR TITLE
feat: add region selection and fix login parameter errors

### DIFF
--- a/matterbridge-roborock-vacuum-plugin.schema.json
+++ b/matterbridge-roborock-vacuum-plugin.schema.json
@@ -2,7 +2,9 @@
   "title": "Matterbridge Roborock Vacuum Plugin",
   "description": "matterbridge-roborock-vacuum-plugin v. 1.1.1-rc09 by https://github.com/RinDevJunior",
   "type": "object",
-  "required": ["username"],
+  "required": [
+    "username"
+  ],
   "properties": {
     "name": {
       "description": "Plugin name",
@@ -29,6 +31,16 @@
       "description": "Roborock account email address",
       "type": "string"
     },
+    "region": {
+      "description": "Roborock account region",
+      "type": "string",
+      "enum": [
+        "US",
+        "EU",
+        "CN"
+      ],
+      "default": "US"
+    },
     "authentication": {
       "description": "Authentication method to use",
       "type": "object",
@@ -49,7 +61,9 @@
               "maxLength": 6
             }
           },
-          "required": ["authenticationMethod"]
+          "required": [
+            "authenticationMethod"
+          ]
         },
         {
           "title": "Password",
@@ -66,11 +80,13 @@
               "ui:widget": "password"
             }
           },
-          "required": ["authenticationMethod", "password"]
+          "required": [
+            "authenticationMethod",
+            "password"
+          ]
         }
       ]
     },
-
     "refreshInterval": {
       "description": "Refresh interval in seconds (default: 60)",
       "type": "number",
@@ -94,7 +110,9 @@
                 "const": true
               }
             },
-            "required": ["enableExperimentalFeature"]
+            "required": [
+              "enableExperimentalFeature"
+            ]
           },
           "then": {
             "properties": {
@@ -156,7 +174,9 @@
                           "const": true
                         }
                       },
-                      "required": ["enableCleanModeMapping"]
+                      "required": [
+                        "enableCleanModeMapping"
+                      ]
                     },
                     "then": {
                       "properties": {
@@ -201,7 +221,9 @@
                                     "default": 25
                                   }
                                 },
-                                "required": ["distanceOff"]
+                                "required": [
+                                  "distanceOff"
+                                ]
                               }
                             }
                           ]
@@ -238,7 +260,9 @@
                                     "default": 25
                                   }
                                 },
-                                "required": ["distanceOff"]
+                                "required": [
+                                  "distanceOff"
+                                ]
                               }
                             }
                           ]
@@ -268,19 +292,35 @@
     "fanMode": {
       "type": "string",
       "description": "Suction power mode to use (e.g., 'Quiet', 'Balanced', 'Turbo', 'Max', 'MaxPlus').",
-      "enum": ["Quiet", "Balanced", "Turbo", "Max", "MaxPlus"],
+      "enum": [
+        "Quiet",
+        "Balanced",
+        "Turbo",
+        "Max",
+        "MaxPlus"
+      ],
       "default": "Balanced"
     },
     "waterFlowMode": {
       "type": "string",
       "description": "Water flow mode to use (e.g., 'Low', 'Medium', 'High', 'CustomizeWithDistanceOff').",
-      "enum": ["Low", "Medium", "High", "CustomizeWithDistanceOff"],
+      "enum": [
+        "Low",
+        "Medium",
+        "High",
+        "CustomizeWithDistanceOff"
+      ],
       "default": "Medium"
     },
     "mopRouteMode": {
       "type": "string",
       "description": "Mop route intensity to use (e.g., 'Standard', 'Deep', 'DeepPlus', 'Fast').",
-      "enum": ["Standard", "Deep", "DeepPlus", "Fast"],
+      "enum": [
+        "Standard",
+        "Deep",
+        "DeepPlus",
+        "Fast"
+      ],
       "default": "Standard"
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -91,12 +91,22 @@ export class RoborockMatterbridgePlatform extends MatterbridgeDynamicPlatform {
       this.log.debug('Using cached deviceId:', deviceId);
     }
 
+    const region = (this.config.region as string)?.toUpperCase() ?? 'US';
+    let baseUrl = 'https://usiot.roborock.com';
+    if (region === 'EU') {
+      baseUrl = 'https://euiot.roborock.com';
+    } else if (region === 'CN') {
+      baseUrl = 'https://iot.roborock.com';
+    }
+    this.log.notice(`Using region: ${region} (${baseUrl})`);
+
     this.roborockService = new RoborockService(
-      () => new RoborockAuthenticateApi(this.log, axiosInstance, deviceId),
+      (logger, url) => new RoborockAuthenticateApi(this.log, axiosInstance, deviceId, url),
       (logger, ud) => new RoborockIoTApi(ud, logger),
       (this.config.refreshInterval as number) ?? 60,
       this.clientManager,
       this.log,
+      baseUrl,
     );
 
     const username = this.config.username as string;

--- a/src/roborockService.ts
+++ b/src/roborockService.ts
@@ -64,14 +64,15 @@ export default class RoborockService {
   private readonly vacuumNeedAPIV3 = ['roborock.vacuum.ss07'];
 
   constructor(
-    authenticateApiSupplier: Factory<void, RoborockAuthenticateApi> = (logger) => new RoborockAuthenticateApi(logger),
+    authenticateApiSupplier: (logger: AnsiLogger, baseUrl: string) => RoborockAuthenticateApi = (logger, baseUrl) => new RoborockAuthenticateApi(logger, undefined, undefined, baseUrl),
     iotApiSupplier: Factory<UserData, RoborockIoTApi> = (logger, ud) => new RoborockIoTApi(ud, logger),
     refreshInterval: number,
     clientManager: ClientManager,
     logger: AnsiLogger,
+    baseUrl = 'https://usiot.roborock.com',
   ) {
     this.logger = logger;
-    this.loginApi = authenticateApiSupplier(logger);
+    this.loginApi = authenticateApiSupplier(logger, baseUrl);
     this.iotApiFactory = iotApiSupplier;
     this.refreshInterval = refreshInterval;
     this.clientManager = clientManager;


### PR DESCRIPTION
The plugin defaults to the US region (https://usiot.roborock.com) even when users have EU or CN accounts. 

This causes the following issue with the verification code authentication method:

1. Authentication to succeed (initial auth works cross-region).
2. getHomeDetails() to fail (wrong regional API endpoint).
3. Plugin loads but shows 0 devices.

#### Summary of changes:
- Added a `region` field to the configuration (US, EU, CN) to support different Roborock API endpoints. It defaults to US.
- Updated the authentication flow to automatically use the correct base URL based on the selected region.
- Fixed the "parameter error code: 1002" during login by adding fallback country information when it's missing from the API response.
- Propagated region settings through the platform and service layers for consistent API communication.

#### Testing

- This fix has been tested locally using matterbridge -add .
- Confirmed EU region connectivity works correctly
- Devices are now properly discovered and exposed