### PR TITLE
Add Roborock Qrevo Plus

### DIFF
--- a/README_SUPPORTED.md
+++ b/README_SUPPORTED.md
@@ -7,6 +7,7 @@
 | Roborock Qrevo Edge 5V1    | `QREVO_EDGE_5V1`       | `roborock.vacuum.a187`        |                  |
 | Roborock S8 Pro Ultra      | `S8_PRO_ULTRA`         | `roborock.vacuum.a70`         |                  |
 | Roborock S7 MaxV           | `S7_MAXV`              | `roborock.vacuum.a27`         |                  |
+| Roborock Qrevo Plus        | `QREVO_PLUS`           | `roborock.vacuum.a123`        |                  |
 
 These devices have been fully tested and are confirmed to work as expected.
 

--- a/src/behaviorFactory.ts
+++ b/src/behaviorFactory.ts
@@ -23,7 +23,8 @@ export function configurateBehavior(
   }
 
   switch (model) {
-    case DeviceModel.QREVO_EDGE_5V1: {
+    case DeviceModel.QREVO_EDGE_5V1:
+    case DeviceModel.QREVO_PLUS: {
       const deviceHandler = new BehaviorDeviceGeneric<EndpointCommandsSmart>(logger);
       setCommandHandlerSmart(duid, deviceHandler, logger, roborockService, cleanModeSettings);
       return deviceHandler;

--- a/src/initialData/getSupportedCleanModes.ts
+++ b/src/initialData/getSupportedCleanModes.ts
@@ -11,6 +11,7 @@ export function getSupportedCleanModes(model: string, enableExperimentalFeature:
 
   switch (model) {
     case DeviceModel.QREVO_EDGE_5V1:
+    case DeviceModel.QREVO_PLUS:
       return getSupportedCleanModesSmart(enableExperimentalFeature);
 
     case DeviceModel.S7_MAXV:

--- a/src/roborockCommunication/Zmodel/deviceModel.ts
+++ b/src/roborockCommunication/Zmodel/deviceModel.ts
@@ -24,4 +24,5 @@ export enum DeviceModel {
   QREVO_MAXV = 'roborock.vacuum.a87',
   QREVO_EDGE_5V1 = 'roborock.vacuum.a187',
   QREVO_EDGE_5AE = 'roborock.vacuum.xxxx',
+  QREVO_PLUS = 'roborock.vacuum.a123',
 }

--- a/src/share/runtimeHelper.ts
+++ b/src/share/runtimeHelper.ts
@@ -12,6 +12,7 @@ export function getCurrentCleanModeFunc(model: string, forceRunAtDefault: boolea
 
   switch (model) {
     case DeviceModel.QREVO_EDGE_5V1:
+    case DeviceModel.QREVO_PLUS:
       return getCurrentCleanModeSmart;
 
     case DeviceModel.S7_MAXV:


### PR DESCRIPTION
I have tried the plugin with my Roborock Qrevo Plus and it works very well. It also supports Smart Mode so I have added it in this PR and tested it with my vacuum.

If I forgot to change something to add the new model just write me a comment.