### PR TITLE
 feat: add smart support for Q Revo MaxV and refactor clean mode logic

### DIFF
--- a/src/constants/device.ts
+++ b/src/constants/device.ts
@@ -9,7 +9,7 @@ import { DeviceModel } from '../roborockCommunication/Zmodel/deviceModel.js';
  * Set of device models that support smart planning features.
  * These models have advanced clean mode capabilities and extended feature sets.
  */
-export const SMART_MODELS = new Set<string>([DeviceModel.QREVO_EDGE_5V1, DeviceModel.QREVO_PLUS]);
+export const SMART_MODELS = new Set<string>([DeviceModel.QREVO_EDGE_5V1, DeviceModel.QREVO_PLUS, DeviceModel.QREVO_MAXV]);
 
 /**
  * Default delay for unregistering devices on shutdown (milliseconds).

--- a/src/initialData/getSupportedCleanModes.ts
+++ b/src/initialData/getSupportedCleanModes.ts
@@ -3,21 +3,16 @@ import { getSupportedCleanModesSmart } from '../behaviors/roborock.vacuum/smart/
 import { getDefaultSupportedCleanModes } from '../behaviors/roborock.vacuum/default/initialData.js';
 import { DeviceModel } from '../roborockCommunication/Zmodel/deviceModel.js';
 import { ExperimentalFeatureSetting } from '../model/ExperimentalFeatureSetting.js';
+import { SMART_MODELS } from '../constants/index.js';
 
-export function getSupportedCleanModes(model: string, enableExperimentalFeature: ExperimentalFeatureSetting | undefined): RvcCleanMode.ModeOption[] {
+export function getSupportedCleanModes(model: DeviceModel, enableExperimentalFeature: ExperimentalFeatureSetting | undefined): RvcCleanMode.ModeOption[] {
   if (enableExperimentalFeature?.advancedFeature?.forceRunAtDefault ?? false) {
     return getDefaultSupportedCleanModes(enableExperimentalFeature);
   }
 
-  switch (model) {
-    case DeviceModel.QREVO_EDGE_5V1:
-    case DeviceModel.QREVO_PLUS:
-      return getSupportedCleanModesSmart(enableExperimentalFeature);
-
-    case DeviceModel.S7_MAXV:
-    case DeviceModel.S8_PRO_ULTRA:
-    case DeviceModel.S6_PURE:
-    default:
-      return getDefaultSupportedCleanModes(enableExperimentalFeature);
+  if (SMART_MODELS.has(model)) {
+    return getSupportedCleanModesSmart(enableExperimentalFeature);
   }
+
+  return getDefaultSupportedCleanModes(enableExperimentalFeature);
 }


### PR DESCRIPTION
Adds smart support for the Roborock Q Revo MaxV (`QREVO_MAXV`) and simplifies `getSupportedCleanModes` by validating against the `SMART_MODELS` set, removing the need for hardcoded switch cases.