### PR TITLE
feat: add default Identify cluster with AudibleBeep type for devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.3-rc04",
       "license": "MIT",
       "dependencies": {
+        "@matter/types": "^0.16.8",
         "@types/node-persist": "3.1.8",
         "axios": "1.13.2",
         "axios-logger": "2.8.1",
@@ -899,6 +900,61 @@
         "@jscpd/core": "4.0.4",
         "reprism": "^0.0.11",
         "spark-md5": "^3.0.2"
+      }
+    },
+    "node_modules/@matter/general": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.16.8.tgz",
+      "integrity": "sha512-ro0KXxCVri5687/bznt8G6UEFWc2zOloJQXa0V+xJOOZQCUPDaVSw/Cej6pik+CdZnMemzD9rsLME8Ai7JO2AQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.0.1"
+      }
+    },
+    "node_modules/@matter/model": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.16.8.tgz",
+      "integrity": "sha512-NtozNBdLu9Acwn0GEY/1Wx3MUSN/ssLAGIZP+WNzM+hVWoWIqI9VuW+6Ws3viWEjC/iDKVimjxFqMKq3ce7Jjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.8"
+      }
+    },
+    "node_modules/@matter/types": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.16.8.tgz",
+      "integrity": "sha512-3unq1c5lDReMosK+BNiqthszcwhdhGljj9ha/syjKyFMT6XENnVOuXsN4b0X6Uzxk52X3abpws1B5h/eEXejnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.8",
+        "@matter/model": "0.16.8"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "vitest": "4.0.17"
   },
   "dependencies": {
+    "@matter/types": "^0.16.8",
     "@types/node-persist": "3.1.8",
     "axios": "1.13.2",
     "axios-logger": "2.8.1",

--- a/src/module.ts
+++ b/src/module.ts
@@ -294,6 +294,12 @@ export class RoborockMatterbridgePlatform extends MatterbridgeDynamicPlatform {
   }
 
   private async addDevice(device: MatterbridgeEndpoint): Promise<MatterbridgeEndpoint | undefined> {
+      // Add the Identify cluster with the IdentifyType attribute
+      // By default, use IdentifyType.AudibleBeep (audible beep)
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { Identify } = require('matterbridge/node_modules/@matter/types/dist/clusters/identify.js');
+      const defaultIdentifyType = Identify.IdentifyType.AudibleBeep;
+      device.createDefaultIdentifyClusterServer(0, defaultIdentifyType);
     if (!device.serialNumber || !device.deviceName) {
       this.log.warn('Cannot add device: missing serialNumber or deviceName');
       return undefined;

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,7 @@ import { NotifyMessageTypes, MessagePayload } from './types/index.js';
 import { getSupportedAreas, getSupportedScenes } from './initialData/index.js';
 
 import { getBaseUrl } from './initialData/regionUrls.js';
+import { Identify } from 'matterbridge/node_modules/@matter/types/dist/esm/clusters/identify.js';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { Device, RoomDto } from './roborockCommunication/models/index.js';
 import { RoborockAuthenticateApi } from './roborockCommunication/api/authClient.js';
@@ -294,12 +295,10 @@ export class RoborockMatterbridgePlatform extends MatterbridgeDynamicPlatform {
   }
 
   private async addDevice(device: MatterbridgeEndpoint): Promise<MatterbridgeEndpoint | undefined> {
-      // Add the Identify cluster with the IdentifyType attribute
-      // By default, use IdentifyType.AudibleBeep (audible beep)
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { Identify } = require('matterbridge/node_modules/@matter/types/dist/clusters/identify.js');
-      const defaultIdentifyType = Identify.IdentifyType.AudibleBeep;
-      device.createDefaultIdentifyClusterServer(0, defaultIdentifyType);
+    // Add the Identify cluster with the IdentifyType attribute
+    // By default, use IdentifyType.AudibleBeep (audible beep)
+    const defaultIdentifyType = Identify.IdentifyType.AudibleBeep;
+    device.createDefaultIdentifyClusterServer(0, defaultIdentifyType);
     if (!device.serialNumber || !device.deviceName) {
       this.log.warn('Cannot add device: missing serialNumber or deviceName');
       return undefined;

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { NotifyMessageTypes, MessagePayload } from './types/index.js';
 import { getSupportedAreas, getSupportedScenes } from './initialData/index.js';
 
 import { getBaseUrl } from './initialData/regionUrls.js';
-import { Identify } from '@matter/types/clusters/identify';
+import { Identify } from '@matter/types';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { Device, RoomDto } from './roborockCommunication/models/index.js';
 import { RoborockAuthenticateApi } from './roborockCommunication/api/authClient.js';

--- a/src/module.ts
+++ b/src/module.ts
@@ -295,10 +295,6 @@ export class RoborockMatterbridgePlatform extends MatterbridgeDynamicPlatform {
   }
 
   private async addDevice(device: MatterbridgeEndpoint): Promise<MatterbridgeEndpoint | undefined> {
-    // Add the Identify cluster with the IdentifyType attribute
-    // By default, use IdentifyType.AudibleBeep (audible beep)
-    const defaultIdentifyType = Identify.IdentifyType.AudibleBeep;
-    device.createDefaultIdentifyClusterServer(0, defaultIdentifyType);
     if (!device.serialNumber || !device.deviceName) {
       this.log.warn('Cannot add device: missing serialNumber or deviceName');
       return undefined;
@@ -324,6 +320,10 @@ export class RoborockMatterbridgePlatform extends MatterbridgeDynamicPlatform {
         options.hardwareVersion = device.hardwareVersion ?? 1;
         options.hardwareVersionString = device.hardwareVersionString ?? '1.0.0';
       }
+      // Add the Identify cluster with the IdentifyType attribute
+      // By default, use IdentifyType.AudibleBeep (audible beep)
+      const defaultIdentifyType = Identify.IdentifyType.AudibleBeep;
+      device.createDefaultIdentifyClusterServer(0, defaultIdentifyType);
       // We need to add bridgedNode device type and BridgedDeviceBasicInformation cluster for single class devices that doesn't add it in childbridge mode.
       if (device.mode === undefined && !device.deviceTypes.has(bridgedNode.code)) {
         device.deviceTypes.set(bridgedNode.code, bridgedNode);

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { NotifyMessageTypes, MessagePayload } from './types/index.js';
 import { getSupportedAreas, getSupportedScenes } from './initialData/index.js';
 
 import { getBaseUrl } from './initialData/regionUrls.js';
-import { Identify } from 'matterbridge/node_modules/@matter/types/dist/esm/clusters/identify.js';
+import { Identify } from '@matter/types/dist/esm/clusters';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { Device, RoomDto } from './roborockCommunication/models/index.js';
 import { RoborockAuthenticateApi } from './roborockCommunication/api/authClient.js';

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { NotifyMessageTypes, MessagePayload } from './types/index.js';
 import { getSupportedAreas, getSupportedScenes } from './initialData/index.js';
 
 import { getBaseUrl } from './initialData/regionUrls.js';
-import { Identify } from '@matter/types';
+import { Identify } from '@matter/types/clusters';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { Device, RoomDto } from './roborockCommunication/models/index.js';
 import { RoborockAuthenticateApi } from './roborockCommunication/api/authClient.js';

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { NotifyMessageTypes, MessagePayload } from './types/index.js';
 import { getSupportedAreas, getSupportedScenes } from './initialData/index.js';
 
 import { getBaseUrl } from './initialData/regionUrls.js';
-import { Identify } from '@matter/types/dist/esm/clusters';
+import { Identify } from '@matter/types/clusters/identify';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { Device, RoomDto } from './roborockCommunication/models/index.js';
 import { RoborockAuthenticateApi } from './roborockCommunication/api/authClient.js';

--- a/src/tests/module.additional.test.ts
+++ b/src/tests/module.additional.test.ts
@@ -83,6 +83,7 @@ describe('module additional tests', () => {
       mode: undefined,
       getClusterServerOptions: (id: number) => ({ deviceTypeList: [] }),
       createDefaultBridgedDeviceBasicInformationClusterServer: vi.fn(),
+      createDefaultIdentifyClusterServer: vi.fn(),
       device: { data: { firmwareVersion: 'v1.2.3' }, fv: undefined },
     };
 


### PR DESCRIPTION
It is necessary to specify a value for the `IdentifyType` attribute (such as `AudibleBeep`) when creating the Identify cluster.
If you do not set this value, Home Assistant will not display the Identify button in the UI. By explicitly setting `IdentifyType`, you ensure the cluster is visible and functional in Home Assistant.


