### PR TITLE
Add base Q Revo (roborock.vacuum.a75) to DeviceModel enum

### DIFF
--- a/src/roborockCommunication/models/deviceModel.ts
+++ b/src/roborockCommunication/models/deviceModel.ts
@@ -14,6 +14,7 @@ export enum DeviceModel {
 	S7_MAXV_ULTRA = 'roborock.vacuum.a65',
 	S7_PRO_ULTRA = 'roborock.vacuum.a62',
 	Q8_MAX = 'roborock.vacuum.a73',
+	Q_REVO = 'roborock.vacuum.a75',
 	S8 = 'roborock.vacuum.a51',
 	S8_PRO_ULTRA = 'roborock.vacuum.a70',
 	S8_MAXV_ULTRA = 'roborock.vacuum.a97',


### PR DESCRIPTION
Resolves #120.

Adds the base Q Revo (`roborock.vacuum.a75`) to the `DeviceModel` enum. Every other Qrevo variant (a87, a101, a104, a117, a123, a135, a187) is already supported — this is the only base-tier model missing.

## Verification

Built and ran against v1.1.5 with this patch applied:

- Verification-code auth ✓
- Cloud device discovery returns the Q Revo correctly ✓
- MQTT status polling delivers full state (battery, charge state, operational state, clean mode, clean area/time) ✓
- Matter RVC endpoint commissions into Apple Home (iOS 18.4+) as a real vacuum tile with start/pause/dock ✓

The a75 shares the protocol surface of the other Qrevo models in the registry, so no other changes are needed.

## DEVICE_EXTRA_MODES

Intentionally not added — the base Q Revo does not have SmartPlan or vac-followed-by-mop. Base clean modes cover its full capability set.