### PR TITLE
1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.6] - 2026-05-16
+
+### Added
+
+- **Base Q Revo device support** — Added `roborock.vacuum.a75` to `DeviceModel` enum.
+
+<a href="https://www.buymeacoffee.com/rinnvspktr" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+---
+
 ## [1.1.5] - 2026-03-15
 
 ### Changed

--- a/docs/claude_history.md
+++ b/docs/claude_history.md
@@ -1,5 +1,14 @@
 # Claude History
 
+## 2026-05-16 (Session)
+
+- Created release 1.1.6
+  - Updated `version` in `package.json` to `1.1.6`
+  - Updated `build:compress` tgz filename in `package.json` to `1.1.6`
+  - Updated `version` in `matterbridge-roborock-vacuum-plugin.config.json` to `1.1.6`
+  - Updated `description` in `matterbridge-roborock-vacuum-plugin.schema.json` to `v. 1.1.6`
+  - Added CHANGELOG entry for `1.1.6`: Base Q Revo (`roborock.vacuum.a75`) added to `DeviceModel` enum
+
 ## 2026-03-14 (Session 17)
 
 - Fixed multi-device polling bug in `PollingService`: second vacuum was stopping first vacuum's polling interval.

--- a/docs/to_do.md
+++ b/docs/to_do.md
@@ -16,6 +16,7 @@
 
 - [x] Fix multi-device polling bug — `PollingService` now uses `Map<duid, Timeout>` so each vacuum has its own interval
 - [x] Fix V1PendingResponseTracker messageId collision — composite key `${duid}:${messageId}` prevents cross-device response routing
+- [x] Release `1.1.6` — Add base Q Revo (`roborock.vacuum.a75`) to `DeviceModel` enum
 - [x] Release `1.1.5-rc08` — refactor `handleServiceAreaUpdate` into dedicated helpers
 - [x] Release `1.1.5-rc07` — correct type of `selectedAreas` (`ServiceArea.Area[]` → `number[]`)
 

--- a/matterbridge-roborock-vacuum-plugin.config.json
+++ b/matterbridge-roborock-vacuum-plugin.config.json
@@ -1,7 +1,7 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
 	"type": "DynamicPlatform",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"authentication": {
 		"username": "",
 		"region": "US",

--- a/matterbridge-roborock-vacuum-plugin.schema.json
+++ b/matterbridge-roborock-vacuum-plugin.schema.json
@@ -1,6 +1,6 @@
 {
 	"title": "Matterbridge Roborock Vacuum Plugin",
-	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.5 by https://github.com/RinDevJunior",
+	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.6 by https://github.com/RinDevJunior",
 	"type": "object",
 	"properties": {
 		"name": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "Matterbridge Roborock Vacuum Plugin",
 	"author": "https://github.com/RinDevJunior",
 	"license": "MIT",
@@ -39,7 +39,7 @@
 		"start": "tsc && matterbridge -childbridge",
 		"cli": "node dist/cli.js",
 		"build:package": "cd .. && build:compress && cd matterbridge-roborock-vacuum-plugin",
-		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.5.tgz matterbridge-roborock-vacuum-plugin",
+		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.6.tgz matterbridge-roborock-vacuum-plugin",
 		"dup-check": "npx jscpd",
 		"build": "tsc",
 		"type-check": "tsc --noEmit",


### PR DESCRIPTION
- **Base Q Revo device support** — Added `roborock.vacuum.a75` to `DeviceModel` enum.

<a href="https://www.buymeacoffee.com/rinnvspktr" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>