### PR TITLE
chore: bump version to 1.1.6 and update matterbridge to 3.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ### ⚠️ Important Notes
 
-Requires matterbridge@3.6.1
+Requires matterbridge@3.9.0
 
 - **Matterbridge must be run in child bridge mode** for proper operation.
 - **By default, one Matterbridge instance supports one Roborock vacuum.**

--- a/matterbridge-roborock-vacuum-plugin.config.json
+++ b/matterbridge-roborock-vacuum-plugin.config.json
@@ -1,7 +1,7 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
 	"type": "DynamicPlatform",
-	"version": "1.1.6",
+	"version": "1.1.7-rc01",
 	"authentication": {
 		"username": "",
 		"region": "US",

--- a/matterbridge-roborock-vacuum-plugin.schema.json
+++ b/matterbridge-roborock-vacuum-plugin.schema.json
@@ -1,6 +1,6 @@
 {
 	"title": "Matterbridge Roborock Vacuum Plugin",
-	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.6 by https://github.com/RinDevJunior",
+	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.7-rc01 by https://github.com/RinDevJunior",
 	"type": "object",
 	"properties": {
 		"name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
-	"version": "1.1.5-rc09",
+	"version": "1.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "matterbridge-roborock-vacuum-plugin",
-			"version": "1.1.5-rc09",
+			"version": "1.1.6",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
-	"version": "1.1.6",
+	"version": "1.1.7-rc01",
 	"description": "Matterbridge Roborock Vacuum Plugin",
 	"author": "https://github.com/RinDevJunior",
 	"license": "MIT",
@@ -33,13 +33,13 @@
 	],
 	"scripts": {
 		"precommit": "npm run lint && npm run type-check && npm run dup-check && npm run format:check && npm run test",
-		"precondition": "npm install -g matterbridge@3.6.1",
+		"precondition": "npm install -g matterbridge@3.9.0",
 		"build:local": "npm run deepClean && npm install && npm link matterbridge && npm run build && npm run matterbridge:add",
 		"build:production": "tsc --project tsconfig.production.json",
 		"start": "tsc && matterbridge -childbridge",
 		"cli": "node dist/cli.js",
 		"build:package": "cd .. && build:compress && cd matterbridge-roborock-vacuum-plugin",
-		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.6.tgz matterbridge-roborock-vacuum-plugin",
+		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.7-rc01.tgz matterbridge-roborock-vacuum-plugin",
 		"dup-check": "npx jscpd",
 		"build": "tsc",
 		"type-check": "tsc --noEmit",

--- a/src/platform/burstPollingManager.ts
+++ b/src/platform/burstPollingManager.ts
@@ -60,7 +60,7 @@ export class BurstPollingManager {
 		const robot = this.platform.registry.robotsMap.get(duid);
 		if (!robot) return true;
 		const state: RvcOperationalState.OperationalState = robot.getAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalState',
 			this.platform.log,
 		);

--- a/src/platform/deviceConfigurator.ts
+++ b/src/platform/deviceConfigurator.ts
@@ -144,7 +144,7 @@ export class DeviceConfigurator {
 				}
 			}
 
-			const options = rvc.getClusterServerOptions(BridgedDeviceBasicInformation.Cluster.id);
+			const options = rvc.getClusterServerOptions(BridgedDeviceBasicInformation.id);
 			if (options) {
 				options.softwareVersion = rvc.softwareVersion ?? 1;
 				options.softwareVersionString = rvc.softwareVersionString ?? '1.0.0';
@@ -157,7 +157,7 @@ export class DeviceConfigurator {
 			// We need to add bridgedNode device type and BridgedDeviceBasicInformation cluster for single class devices that doesn't add it in childbridge mode.
 			if (rvc.mode === undefined && !rvc.deviceTypes.has(bridgedNode.code)) {
 				rvc.deviceTypes.set(bridgedNode.code, bridgedNode);
-				const options = rvc.getClusterServerOptions(Descriptor.Cluster.id);
+				const options = rvc.getClusterServerOptions(Descriptor.id);
 				if (options) {
 					const deviceTypeList = options.deviceTypeList as { deviceType: number; revision: number }[];
 					if (!deviceTypeList.find((dt) => dt.deviceType === bridgedNode.code)) {

--- a/src/platformRunner.ts
+++ b/src/platformRunner.ts
@@ -149,7 +149,7 @@ export class PlatformRunner {
 		}
 		this.platform.log.debug(`Handling error occurred: ${debugStringify(message)}`);
 		const currentOperationState: RvcOperationalState.OperationalState = robot.getAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalState',
 			this.platform.log,
 		);
@@ -160,13 +160,13 @@ export class PlatformRunner {
 			const errorDetail = vacuumStatus.getErrorState();
 			this.platform.log.warn(`Vacuum error detected: ${getOperationalErrorName(errorDetail)}`);
 			await robot.updateAttribute(
-				RvcOperationalState.Cluster.id,
+				RvcOperationalState.id,
 				'operationalState',
 				RvcOperationalState.OperationalState.Error,
 				this.platform.log,
 			);
 			await robot.updateAttribute(
-				RvcOperationalState.Cluster.id,
+				RvcOperationalState.id,
 				'operationalError',
 				{ errorStateId: errorDetail },
 				this.platform.log,
@@ -178,7 +178,7 @@ export class PlatformRunner {
 		if (currentOperationState === RvcOperationalState.OperationalState.Running) {
 			this.platform.log.debug('Vacuum running without errors, clearing error state.');
 			await robot.updateAttribute(
-				RvcOperationalState.Cluster.id,
+				RvcOperationalState.id,
 				'operationalError',
 				{ errorStateId: RvcOperationalState.ErrorState.NoError },
 				this.platform.log,
@@ -197,7 +197,7 @@ export class PlatformRunner {
 
 			if (dockStatus.hasError()) {
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalState',
 					RvcOperationalState.OperationalState.Error,
 					this.platform.log,
@@ -205,7 +205,7 @@ export class PlatformRunner {
 				const errorDetail = dockStatus.getMatterOperationalError();
 				this.platform.log.warn(`Docking station error detected: ${getOperationalErrorName(errorDetail)}`);
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalError',
 					{ errorStateId: errorDetail },
 					this.platform.log,
@@ -213,7 +213,7 @@ export class PlatformRunner {
 			} else {
 				this.platform.log.debug('No docking station errors detected.');
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalError',
 					{ errorStateId: RvcOperationalState.ErrorState.NoError },
 					this.platform.log,
@@ -227,7 +227,7 @@ export class PlatformRunner {
 			if (dockStatus !== RvcOperationalState.ErrorState.NoError) {
 				this.platform.log.warn(`Docking station error detected: ${getOperationalErrorName(dockStatus)}`);
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalError',
 					{ errorStateId: dockStatus },
 					this.platform.log,
@@ -235,7 +235,7 @@ export class PlatformRunner {
 			} else {
 				this.platform.log.debug('No docking station errors detected.');
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalError',
 					{ errorStateId: RvcOperationalState.ErrorState.NoError },
 					this.platform.log,
@@ -248,7 +248,7 @@ export class PlatformRunner {
 		// No errors detected and no dock station processing
 		this.platform.log.debug('No errors detected, clearing operational error state.');
 		await robot.updateAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalError',
 			{ errorStateId: RvcOperationalState.ErrorState.NoError },
 			this.platform.log,
@@ -265,16 +265,16 @@ export class PlatformRunner {
 		const batteryChargeLevel = getBatteryStatus(batteryLevel);
 
 		if (batteryLevel) {
-			await robot.updateAttribute(PowerSource.Cluster.id, 'batPercentRemaining', batteryLevel * 2, this.platform.log);
-			await robot.updateAttribute(PowerSource.Cluster.id, 'batChargeLevel', batteryChargeLevel, this.platform.log);
+			await robot.updateAttribute(PowerSource.id, 'batPercentRemaining', batteryLevel * 2, this.platform.log);
+			await robot.updateAttribute(PowerSource.id, 'batChargeLevel', batteryChargeLevel, this.platform.log);
 		}
 
 		if (batteryLevel && deviceStatus) {
 			const batteryChargeState = getBatteryState(deviceStatus, batteryLevel);
-			await robot.updateAttribute(PowerSource.Cluster.id, 'batChargeState', batteryChargeState, this.platform.log);
+			await robot.updateAttribute(PowerSource.id, 'batChargeState', batteryChargeState, this.platform.log);
 
 			const currentOperationState: RvcOperationalState.OperationalState = robot.getAttribute(
-				RvcOperationalState.Cluster.id,
+				RvcOperationalState.id,
 				'operationalState',
 				this.platform.log,
 			);
@@ -283,7 +283,7 @@ export class PlatformRunner {
 				currentOperationState === RvcOperationalState.OperationalState.Docked
 			) {
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalState',
 					RvcOperationalState.OperationalState.Charging,
 					this.platform.log,
@@ -295,7 +295,7 @@ export class PlatformRunner {
 				currentOperationState === RvcOperationalState.OperationalState.Charging
 			) {
 				await robot.updateAttribute(
-					RvcOperationalState.Cluster.id,
+					RvcOperationalState.id,
 					'operationalState',
 					RvcOperationalState.OperationalState.Docked,
 					this.platform.log,
@@ -319,10 +319,10 @@ export class PlatformRunner {
 			return;
 		}
 
-		const currentRunMode: number = robot.getAttribute(RvcRunMode.Cluster.id, 'currentMode');
+		const currentRunMode: number = robot.getAttribute(RvcRunMode.id, 'currentMode');
 
 		const currentOperationState: RvcOperationalState.OperationalState = robot.getAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalState',
 		);
 
@@ -348,14 +348,9 @@ export class PlatformRunner {
 		}
 
 		// Update Matter attributes
+		await robot.updateAttribute(RvcRunMode.id, 'currentMode', getRunningMode(resolvedState.runMode), this.platform.log);
 		await robot.updateAttribute(
-			RvcRunMode.Cluster.id,
-			'currentMode',
-			getRunningMode(resolvedState.runMode),
-			this.platform.log,
-		);
-		await robot.updateAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalState',
 			resolvedState.operationalState,
 			this.platform.log,
@@ -385,7 +380,7 @@ export class PlatformRunner {
 			`Resolved state from simple update: ${state !== undefined ? getRunModeName(state) : 'undefined'}`,
 		);
 		if (state !== undefined) {
-			await robot.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', getRunningMode(state), this.platform.log);
+			await robot.updateAttribute(RvcRunMode.id, 'currentMode', getRunningMode(state), this.platform.log);
 		}
 
 		const includeDockStationStatus = this.platform.configManager.includeDockStationStatus;
@@ -397,12 +392,7 @@ export class PlatformRunner {
 		}
 		if (operationalStateId !== undefined) {
 			this.platform.log.debug(`Updating operational state to: ${getOperationalStateName(operationalStateId)}`);
-			await robot.updateAttribute(
-				RvcOperationalState.Cluster.id,
-				'operationalState',
-				operationalStateId,
-				this.platform.log,
-			);
+			await robot.updateAttribute(RvcOperationalState.id, 'operationalState', operationalStateId, this.platform.log);
 		}
 	}
 
@@ -439,7 +429,7 @@ export class PlatformRunner {
 
 			if (currentCleanMode) {
 				this.platform.log.notice(`Calculated current clean mode: ${getCleanModeName(currentCleanMode)}`);
-				await robot.updateAttribute(RvcCleanMode.Cluster.id, 'currentMode', currentCleanMode, this.platform.log);
+				await robot.updateAttribute(RvcCleanMode.id, 'currentMode', currentCleanMode, this.platform.log);
 			}
 		}
 	}
@@ -458,7 +448,7 @@ export class PlatformRunner {
 		if (message.state === OperationStatusCode.Idle) {
 			logger.debug('Robot is idle, updating selectedAreas from Roborock service');
 			const selectedAreas = this.platform.roborockService?.getSelectedAreas(robot.device.duid) ?? [];
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'selectedAreas', selectedAreas, logger);
+			await robot.updateAttribute(ServiceArea.id, 'selectedAreas', selectedAreas, logger);
 			return;
 		}
 
@@ -477,7 +467,7 @@ export class PlatformRunner {
 
 	private getSelectedAreas(robot: RoborockVacuumCleaner, message: ServiceAreaUpdateMessage): number[] {
 		return (
-			robot.getAttribute(ServiceArea.Cluster.id, 'selectedAreas', this.platform.log) ??
+			robot.getAttribute(ServiceArea.id, 'selectedAreas', this.platform.log) ??
 			this.platform.roborockService?.getSelectedAreas(message.duid) ??
 			[]
 		);
@@ -494,19 +484,19 @@ export class PlatformRunner {
 
 		if (message.cleaningProcess.clean_area === 0 || message.cleaningProcess.clean_time === 0) {
 			// Robot not started cleaning yet → "Traveling to room"
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'selectedAreas', selectedAreas, logger);
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'currentArea', null, logger);
+			await robot.updateAttribute(ServiceArea.id, 'selectedAreas', selectedAreas, logger);
+			await robot.updateAttribute(ServiceArea.id, 'currentArea', null, logger);
 			return;
 		}
 
 		if (selectedAreas.length === 1) {
 			// Single room → "Cleaning (Room)"
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'selectedAreas', selectedAreas, logger);
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'currentArea', selectedAreas[0], logger);
+			await robot.updateAttribute(ServiceArea.id, 'selectedAreas', selectedAreas, logger);
+			await robot.updateAttribute(ServiceArea.id, 'currentArea', selectedAreas[0], logger);
 		} else {
 			// Multiple rooms, no cleaningInfo → "Preparing" (workaround)
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'selectedAreas', [], logger);
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'currentArea', null, logger);
+			await robot.updateAttribute(ServiceArea.id, 'selectedAreas', [], logger);
+			await robot.updateAttribute(ServiceArea.id, 'currentArea', null, logger);
 		}
 	}
 
@@ -542,7 +532,7 @@ export class PlatformRunner {
         segment_id: ${segment_id},
         currentMappedAreas: ${debugStringify(roomIndexMap)}`,
 			);
-			await robot.updateAttribute(ServiceArea.Cluster.id, 'currentArea', null, logger);
+			await robot.updateAttribute(ServiceArea.id, 'currentArea', null, logger);
 			return;
 		}
 
@@ -557,6 +547,6 @@ export class PlatformRunner {
       activeArea: ${debugStringify(activeArea)}`,
 		);
 
-		await robot.updateAttribute(ServiceArea.Cluster.id, 'currentArea', mappedArea, logger);
+		await robot.updateAttribute(ServiceArea.id, 'currentArea', mappedArea, logger);
 	}
 }

--- a/src/runtimes/handleLocalMessage.ts
+++ b/src/runtimes/handleLocalMessage.ts
@@ -12,7 +12,7 @@ export async function triggerDssError(
 	platform: RoborockMatterbridgePlatform,
 ): Promise<boolean> {
 	const currentOperationState = robot.getAttribute(
-		RvcOperationalState.Cluster.id,
+		RvcOperationalState.id,
 		'operationalState',
 	) as RvcOperationalState.OperationalState;
 	if (currentOperationState === RvcOperationalState.OperationalState.Error) {
@@ -21,7 +21,7 @@ export async function triggerDssError(
 
 	if (currentOperationState === RvcOperationalState.OperationalState.Docked) {
 		await robot.updateAttribute(
-			RvcOperationalState.Cluster.id,
+			RvcOperationalState.id,
 			'operationalState',
 			RvcOperationalState.OperationalState.Error,
 			platform.log,

--- a/src/tests/behaviors/roborock.vacuum/core/cleanModeConfig.test.ts
+++ b/src/tests/behaviors/roborock.vacuum/core/cleanModeConfig.test.ts
@@ -7,8 +7,11 @@ import {
 	getModeDisplayMap,
 	getModeOptions,
 	getModeSettingsMap,
-	smartCleanModeConfigs,
+	smartPlanModeConfig,
+	vacFollowedByMopModeConfig,
 } from '../../../../behaviors/roborock.vacuum/core/cleanModeConfig.js';
+
+const smartCleanModeConfigs = [smartPlanModeConfig, vacFollowedByMopModeConfig, ...baseCleanModeConfigs];
 import { CleanModeSetting } from '../../../../behaviors/roborock.vacuum/core/CleanModeSetting.js';
 
 describe('cleanModeConfig', () => {
@@ -79,8 +82,8 @@ describe('cleanModeConfig', () => {
 
 		it('should not include setting property in options', () => {
 			const options = getModeOptions(baseCleanModeConfigs);
-			const first = options[0] as Record<string, unknown>;
-			expect(first['setting']).toBeUndefined();
+			const first = options[0];
+			expect('setting' in first).toBe(false);
 		});
 	});
 

--- a/src/tests/roborockVacuumCleaner.test.ts
+++ b/src/tests/roborockVacuumCleaner.test.ts
@@ -80,12 +80,7 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('identify', {
-			request: { identifyTime: 5 },
-			cluster: 1,
-			attributes: {},
-			endpoint: 1,
-		});
+		await vacuum.executeCommandHandler('identify', { identifyTime: 5 }, 'identify', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('identify', 5);
 	});
 
@@ -97,7 +92,7 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('selectAreas', { request: { newAreas: [] } });
+		await vacuum.executeCommandHandler('selectAreas', { newAreas: [] }, 'serviceArea', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).not.toHaveBeenCalled();
 	});
 
@@ -109,7 +104,13 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('selectAreas', { newAreas: [1, 2] });
+		await vacuum.executeCommandHandler(
+			'selectAreas',
+			{ newAreas: [1, 2] },
+			'serviceArea',
+			asType({}),
+			asType(undefined),
+		);
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('selectAreas', [1, 2]);
 	});
 
@@ -122,7 +123,7 @@ describe('RoborockVacuumCleaner', () => {
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
 		const request = { newMode: 42 } satisfies ModeBase.ChangeToModeRequest;
-		await vacuum.executeCommandHandler('changeToMode', request);
+		await vacuum.executeCommandHandler('changeToMode', request, 'modeSelect', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('changeToMode', 42);
 	});
 
@@ -134,7 +135,7 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('pause', { request: {} });
+		await vacuum.executeCommandHandler('pause', {}, 'operationalState', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('pause');
 	});
 
@@ -146,7 +147,7 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('resume', { request: {} });
+		await vacuum.executeCommandHandler('resume', {}, 'operationalState', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('resume');
 	});
 
@@ -158,7 +159,7 @@ describe('RoborockVacuumCleaner', () => {
 			commands: {},
 		} satisfies BehaviorFactoryResult;
 		vacuum.configureHandler(behaviorHandler);
-		await vacuum.executeCommandHandler('goHome', { request: {} });
+		await vacuum.executeCommandHandler('goHome', {}, 'rvcOperationalState', asType({}), asType(undefined));
 		expect(behaviorHandler.executeCommand).toHaveBeenCalledWith('goHome');
 	});
 


### PR DESCRIPTION
- Replace `.Cluster.id` with `.id` across all cluster attribute calls
- Update matterbridge precondition from 3.6.1 to 3.9.0
- Refactor executeCommandHandler call signatures in tests
- Export individual clean mode configs instead of combined array
- Inline updateAttribute calls where multi-line formatting adds no value