### PR TITLE
fix: update glob and grep tool

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,13 +42,7 @@ If `.codegraph/` exists at the repo root, use it before Grep/Glob/Read to locate
 
 ## Glob / Grep (file search — platform-aware)
 
-`Glob` and `Grep` are first-party tools on **Windows and remote/web** sessions. On **macOS/Linux native** builds they are replaced by MCP equivalents registered in `.mcp.json`. Always resolve at runtime:
-
-1. If `Glob` / `Grep` appear in your toolset → use them directly (Windows / remote).
-2. If not, check for `mcp__glob-grep__Glob` / `mcp__glob-grep__Grep` → use those (macOS / Linux native).
-3. If neither is available → fall back to `Bash` with `rg` / `find`.
-
-Both the first-party tools and the MCP equivalents respect `.gitignore`. The Bash fallback does not — avoid it for searches where gitignored paths (e.g. `node_modules`) would pollute results.
+On **Windows and remote/web** sessions, `Glob` and `Grep` are first-party tools — use them directly. On **macOS/Linux native** builds, use `mcp__glob-grep__Glob` / `mcp__glob-grep__Grep` instead (registered in `.mcp.json`). Fall back to `Bash` with `rg`/`find` only if neither is in your toolset. Both first-party and MCP variants respect `.gitignore`; the Bash fallback does not.
 
 ## LSP (code navigation — when available)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,16 @@ Project instructions for Claude Code. Orchestration source of truth: `.claude/`.
 
 If `.codegraph/` exists at the repo root, use it before Grep/Glob/Read to locate or understand code: MCP `codegraph_explore` when available, else shell `codegraph explore "<query>"` (required for subagents, which lack MCP access). No `.codegraph/` → skip it.
 
+## Glob / Grep (file search — platform-aware)
+
+`Glob` and `Grep` are first-party tools on **Windows and remote/web** sessions. On **macOS/Linux native** builds they are replaced by MCP equivalents registered in `.mcp.json`. Always resolve at runtime:
+
+1. If `Glob` / `Grep` appear in your toolset → use them directly (Windows / remote).
+2. If not, check for `mcp__glob-grep__Glob` / `mcp__glob-grep__Grep` → use those (macOS / Linux native).
+3. If neither is available → fall back to `Bash` with `rg` / `find`.
+
+Both the first-party tools and the MCP equivalents respect `.gitignore`. The Bash fallback does not — avoid it for searches where gitignored paths (e.g. `node_modules`) would pollute results.
+
 ## LSP (code navigation — when available)
 
 The `LSP` tool exists on the local machine (`typescript-language-server`) but NOT in remote/web sessions. **Check your toolset first: if `LSP` is not listed, skip it silently — do not attempt the call.** When available, prefer it over Grep for symbol lookups: `findReferences` for usages, `goToDefinition` for definitions, `prepareCallHierarchy` + `incomingCalls`/`outgoingCalls` for call traces, `documentSymbol` / `workspaceSymbol` to locate symbols. When absent, Grep the symbol with a word-boundary pattern (e.g. `\bgetRoomMap\b`) and check `index.ts` barrel files for re-exports.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
 		"type": "command",
 		"command": "bash .claude/statusline-command.sh"
 	},
+	"enabledMcpjsonServers": ["glob-grep"],
 	"includeCoAuthoredBy": false,
 	"permissions": {
 		"allow": []

--- a/.claude/tools/glob-grep-server.cjs
+++ b/.claude/tools/glob-grep-server.cjs
@@ -40,13 +40,20 @@ function sendError(id, code, message) {
  * Convert a glob pattern (with optional base path override) to a `find` command
  * and execute it. Returns newline-joined paths or '(no results)'.
  */
+function detectRg() {
+  try {
+    execSync('which rg', { stdio: 'ignore' });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function runGlob({ pattern, path: basePath }) {
   const searchPath = basePath || '.';
 
-  // Split pattern into segments
   const segments = pattern.split('/');
 
-  // Find the first segment that contains a wildcard
   let staticSegments = [];
   let wildcardStart = -1;
   for (let i = 0; i < segments.length; i++) {
@@ -57,34 +64,31 @@ function runGlob({ pattern, path: basePath }) {
     staticSegments.push(segments[i]);
   }
 
-  // Remaining segments after static prefix
   const dynamicSegments = wildcardStart >= 0 ? segments.slice(wildcardStart) : segments;
-
-  // The filename pattern is the last segment
   const filePattern = dynamicSegments[dynamicSegments.length - 1];
-
-  // Directory segments between static prefix and filename
   const dirSegments = dynamicSegments.slice(0, dynamicSegments.length - 1);
 
-  // Build the find base dir: searchPath + static prefix
   let findBase = searchPath;
   if (staticSegments.length > 0) {
-    // Avoid double-slash
     findBase = searchPath.replace(/\/+$/, '') + '/' + staticSegments.join('/');
   }
 
-  // Determine maxdepth
   const hasRecursiveGlob = dirSegments.some((s) => s === '**');
-  let maxDepthFlag = '';
-  if (!hasRecursiveGlob) {
-    const depth = dirSegments.length + 1;
-    maxDepthFlag = `-maxdepth ${depth}`;
-  }
+  const maxDepth = hasRecursiveGlob ? null : dirSegments.length + 1;
 
-  // Escape single quotes in filePattern for shell
   const safeFilePattern = filePattern.replace(/'/g, "'\\''");
+  const safeFindBase = findBase.replace(/'/g, "'\\''");
 
-  const cmd = `find ${findBase} ${maxDepthFlag} -name '${safeFilePattern}' -not -path '*/.git/*' 2>/dev/null | sort`;
+  let cmd;
+  if (detectRg()) {
+    // rg --files respects .gitignore by default
+    const depthFlag = maxDepth != null ? `--max-depth ${maxDepth}` : '';
+    cmd = `rg --files ${depthFlag} --glob '${safeFilePattern}' -- '${safeFindBase}' 2>/dev/null | sort`;
+  } else {
+    // find fallback: excludes .git/node_modules but does not parse .gitignore
+    const depthFlag = maxDepth != null ? `-maxdepth ${maxDepth}` : '';
+    cmd = `find '${safeFindBase}' ${depthFlag} -name '${safeFilePattern}' -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | sort`;
+  }
 
   try {
     const output = execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
@@ -104,18 +108,9 @@ function runGrep({ pattern, path: searchPath, glob, type, '-i': caseInsensitive,
   const base = searchPath || '.';
   const mode = output_mode || 'files_with_matches';
 
-  // Detect rg
-  let hasRg = false;
-  try {
-    execSync('which rg', { stdio: 'ignore' });
-    hasRg = true;
-  } catch (_) {
-    hasRg = false;
-  }
-
   let cmd;
 
-  if (hasRg) {
+  if (detectRg()) {
     const flags = ['--no-heading'];
     if (caseInsensitive) flags.push('-i');
     if (glob) flags.push(`--glob '${glob.replace(/'/g, "'\\''")}'`);
@@ -127,8 +122,8 @@ function runGrep({ pattern, path: searchPath, glob, type, '-i': caseInsensitive,
     flags.push(`'${base.replace(/'/g, "'\\''")}'`);
     cmd = `rg ${flags.join(' ')} 2>/dev/null`;
   } else {
-    // grep fallback
-    const flags = ['-r', '-E'];
+    // grep fallback: excludes .git/node_modules but does not parse .gitignore
+    const flags = ['-r', '-E', '--exclude-dir=.git', '--exclude-dir=node_modules'];
     if (caseInsensitive) flags.push('-i');
     if (glob) flags.push(`--include='${glob.replace(/'/g, "'\\''")}'`);
     if (mode === 'files_with_matches') flags.push('-l');

--- a/.claude/tools/glob-grep-server.cjs
+++ b/.claude/tools/glob-grep-server.cjs
@@ -1,0 +1,272 @@
+'use strict';
+
+// MCP stdio server — Glob + Grep tools
+// Node built-ins only; no npm dependencies.
+
+const { execSync } = require('child_process');
+const readline = require('readline');
+
+// ---------------------------------------------------------------------------
+// Transport helpers
+// ---------------------------------------------------------------------------
+
+function send(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function sendResult(id, content) {
+  send({
+    jsonrpc: '2.0',
+    id,
+    result: {
+      content: [{ type: 'text', text: content }],
+    },
+  });
+}
+
+function sendError(id, code, message) {
+  send({
+    jsonrpc: '2.0',
+    id,
+    error: { code, message },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Glob tool implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a glob pattern (with optional base path override) to a `find` command
+ * and execute it. Returns newline-joined paths or '(no results)'.
+ */
+function runGlob({ pattern, path: basePath }) {
+  const searchPath = basePath || '.';
+
+  // Split pattern into segments
+  const segments = pattern.split('/');
+
+  // Find the first segment that contains a wildcard
+  let staticSegments = [];
+  let wildcardStart = -1;
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].includes('*') || segments[i].includes('?')) {
+      wildcardStart = i;
+      break;
+    }
+    staticSegments.push(segments[i]);
+  }
+
+  // Remaining segments after static prefix
+  const dynamicSegments = wildcardStart >= 0 ? segments.slice(wildcardStart) : segments;
+
+  // The filename pattern is the last segment
+  const filePattern = dynamicSegments[dynamicSegments.length - 1];
+
+  // Directory segments between static prefix and filename
+  const dirSegments = dynamicSegments.slice(0, dynamicSegments.length - 1);
+
+  // Build the find base dir: searchPath + static prefix
+  let findBase = searchPath;
+  if (staticSegments.length > 0) {
+    // Avoid double-slash
+    findBase = searchPath.replace(/\/+$/, '') + '/' + staticSegments.join('/');
+  }
+
+  // Determine maxdepth
+  const hasRecursiveGlob = dirSegments.some((s) => s === '**');
+  let maxDepthFlag = '';
+  if (!hasRecursiveGlob) {
+    const depth = dirSegments.length + 1;
+    maxDepthFlag = `-maxdepth ${depth}`;
+  }
+
+  // Escape single quotes in filePattern for shell
+  const safeFilePattern = filePattern.replace(/'/g, "'\\''");
+
+  const cmd = `find ${findBase} ${maxDepthFlag} -name '${safeFilePattern}' -not -path '*/.git/*' 2>/dev/null | sort`;
+
+  try {
+    const output = execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const trimmed = output.trim();
+    return trimmed.length > 0 ? trimmed : '(no results)';
+  } catch (err) {
+    const output = (err.stdout || '').trim();
+    return output.length > 0 ? output : '(no results)';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Grep tool implementation
+// ---------------------------------------------------------------------------
+
+function runGrep({ pattern, path: searchPath, glob, type, '-i': caseInsensitive, output_mode, context, head_limit }) {
+  const base = searchPath || '.';
+  const mode = output_mode || 'files_with_matches';
+
+  // Detect rg
+  let hasRg = false;
+  try {
+    execSync('which rg', { stdio: 'ignore' });
+    hasRg = true;
+  } catch (_) {
+    hasRg = false;
+  }
+
+  let cmd;
+
+  if (hasRg) {
+    const flags = ['--no-heading'];
+    if (caseInsensitive) flags.push('-i');
+    if (glob) flags.push(`--glob '${glob.replace(/'/g, "'\\''")}'`);
+    if (type) flags.push(`--type '${type.replace(/'/g, "'\\''")}'`);
+    if (mode === 'files_with_matches') flags.push('-l');
+    else if (mode === 'count') flags.push('-c');
+    if (context != null && mode === 'content') flags.push(`-C ${Number(context)}`);
+    flags.push(`-- '${pattern.replace(/'/g, "'\\''")}'`);
+    flags.push(`'${base.replace(/'/g, "'\\''")}'`);
+    cmd = `rg ${flags.join(' ')} 2>/dev/null`;
+  } else {
+    // grep fallback
+    const flags = ['-r', '-E'];
+    if (caseInsensitive) flags.push('-i');
+    if (glob) flags.push(`--include='${glob.replace(/'/g, "'\\''")}'`);
+    if (mode === 'files_with_matches') flags.push('-l');
+    else if (mode === 'count') flags.push('-c');
+    if (context != null && mode === 'content') flags.push(`-C ${Number(context)}`);
+    flags.push(`-- '${pattern.replace(/'/g, "'\\''")}'`);
+    flags.push(`'${base.replace(/'/g, "'\\''")}'`);
+    cmd = `grep ${flags.join(' ')} 2>/dev/null`;
+  }
+
+  let output = '';
+  try {
+    output = execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch (err) {
+    // grep/rg exit 1 means no matches (not an error per se)
+    output = err.stdout || '';
+  }
+
+  output = output.trim();
+
+  if (head_limit != null && output.length > 0) {
+    const lines = output.split('\n');
+    output = lines.slice(0, Number(head_limit)).join('\n');
+  }
+
+  return output.length > 0 ? output : '(no results)';
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const TOOL_DEFINITIONS = [
+  {
+    name: 'Glob',
+    description: 'Fast file pattern matching tool. Returns matching file paths sorted by modification time.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Glob pattern to match files against' },
+        path: { type: 'string', description: 'Directory to search in (optional)' },
+      },
+      required: ['pattern'],
+    },
+  },
+  {
+    name: 'Grep',
+    description: 'Search file contents with regex. Supports glob filter, type filter, context lines, and output modes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Regex pattern to search for' },
+        path: { type: 'string', description: 'File or directory to search in (optional)' },
+        glob: { type: 'string', description: 'Glob pattern to filter files (e.g. "*.ts")' },
+        type: { type: 'string', description: 'File type to search (e.g. "js", "py")' },
+        '-i': { type: 'boolean', description: 'Case insensitive search' },
+        output_mode: {
+          type: 'string',
+          enum: ['content', 'files_with_matches', 'count'],
+          description: 'Output mode (default: files_with_matches)',
+        },
+        context: { type: 'number', description: 'Lines of context around matches (content mode only)' },
+        head_limit: { type: 'number', description: 'Limit output to first N lines' },
+      },
+      required: ['pattern'],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Request dispatcher
+// ---------------------------------------------------------------------------
+
+function handleRequest(req) {
+  const { jsonrpc, id, method, params } = req;
+
+  // Notifications (no id) — no response
+  if (id === undefined || id === null) {
+    return;
+  }
+
+  if (method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        protocolVersion: '2024-11-05',
+        serverInfo: { name: 'glob-grep-server', version: '1.0.0' },
+        capabilities: { tools: {} },
+      },
+    });
+    return;
+  }
+
+  if (method === 'tools/list') {
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: { tools: TOOL_DEFINITIONS },
+    });
+    return;
+  }
+
+  if (method === 'tools/call') {
+    const { name, arguments: args } = params || {};
+    try {
+      let text;
+      if (name === 'Glob') {
+        text = runGlob(args || {});
+      } else if (name === 'Grep') {
+        text = runGrep(args || {});
+      } else {
+        sendError(id, -32601, `Unknown tool: ${name}`);
+        return;
+      }
+      sendResult(id, text);
+    } catch (err) {
+      sendResult(id, `Error: ${err.message}`);
+    }
+    return;
+  }
+
+  sendError(id, -32601, `Method not found: ${method}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main — read newline-delimited JSON from stdin
+// ---------------------------------------------------------------------------
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  try {
+    const req = JSON.parse(trimmed);
+    handleRequest(req);
+  } catch (_) {
+    // Malformed JSON — ignore
+  }
+});

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,11 @@
 			"type": "stdio",
 			"command": "codegraph",
 			"args": ["serve", "--mcp"]
+		},
+		"glob-grep": {
+			"type": "stdio",
+			"command": "node",
+			"args": [".claude/tools/glob-grep-server.cjs"]
 		}
 	}
 }


### PR DESCRIPTION
Fixes three bugs in the simple device status update path:
- Issue 1: pass `message.status` (OperationStatusCode) instead of
  ModeTag to `state_to_matter_operational_status`; all calls were
  falling through to `Docked`
- Issue 2: `getBatteryState` returned `IsAtFullCharge` for active
  states (Cleaning, Paused, etc.), risking a false → Docked
  transition; changed default to `IsNotCharging`
- Issue 3: falsy check in `updateFromHomeData` silently dropped 0%
  battery; changed to `!= null`

Also moves DSS error check before run-mode update in
`handleDeviceStatusSimpleUpdate` to match the full-update path,
adds a per-robot `lastUpdateAt` timestamp, and introduces a
watchdog timer that logs an error when no status update is
received within 5 minutes.

Documents all six issues in `docs/status-update-flow-issues.md`
and adds them to `docs/to_do.md`.