### PR TITLE
fix: correct Q10 MaxPlus suction power wire value mapping

### DIFF
--- a/src/roborockCommunication/helper/B01VacuumModeResolver.ts
+++ b/src/roborockCommunication/helper/B01VacuumModeResolver.ts
@@ -1,7 +1,8 @@
 import { Q7MopRoute, Q7MopWaterFlow, Q7VacuumSuctionPower } from '../../behaviors/roborock.vacuum/b01/q7.js';
+import { VacuumSuctionPower } from '../../behaviors/roborock.vacuum/enums/VacuumSuctionPower.js';
 
 export const B01VacuumModeResolver = {
-	resolveVacuumMode(suctionPower: number): number {
+	resolveQ7VacuumMode(suctionPower: number): number {
 		switch (suctionPower) {
 			case Q7VacuumSuctionPower.Quiet:
 				return 1;
@@ -13,6 +14,23 @@ export const B01VacuumModeResolver = {
 				return 4;
 			case Q7VacuumSuctionPower.MaxPlus:
 				return 5;
+			default:
+				return 0;
+		}
+	},
+
+	resolveQ10VacuumMode(suctionPower: number): number {
+		switch (suctionPower) {
+			case VacuumSuctionPower.Quiet:
+				return 1;
+			case VacuumSuctionPower.Balanced:
+				return 2;
+			case VacuumSuctionPower.Turbo:
+				return 3;
+			case VacuumSuctionPower.Max:
+				return 4;
+			case VacuumSuctionPower.MaxPlus:
+				return 8;
 			default:
 				return 0;
 		}

--- a/src/roborockCommunication/protocol/dispatcher/Q10MessageDispatcher.ts
+++ b/src/roborockCommunication/protocol/dispatcher/Q10MessageDispatcher.ts
@@ -198,7 +198,7 @@ export class Q10MessageDispatcher implements AbstractMessageDispatcher {
 		const request = new RequestMessage({
 			messageId: this.messageId,
 			dps: {
-				[Q10RequestMethod.change_vacuum_mode]: B01VacuumModeResolver.resolveVacuumMode(mode),
+				[Q10RequestMethod.change_vacuum_mode]: B01VacuumModeResolver.resolveQ10VacuumMode(mode),
 			},
 		});
 		return this.client.send(duid, request);

--- a/src/roborockCommunication/protocol/dispatcher/Q7MessageDispatcher.ts
+++ b/src/roborockCommunication/protocol/dispatcher/Q7MessageDispatcher.ts
@@ -246,7 +246,9 @@ export class Q7MessageDispatcher implements AbstractMessageDispatcher {
 	private setVacuumMode(duid: string, suctionPower: number): Promise<void> {
 		const request = new RequestMessage({
 			messageId: this.messageId,
-			dps: this.createDps(Q7RequestMethod.set_prop, { 'wind': B01VacuumModeResolver.resolveVacuumMode(suctionPower) }),
+			dps: this.createDps(Q7RequestMethod.set_prop, {
+				'wind': B01VacuumModeResolver.resolveQ7VacuumMode(suctionPower),
+			}),
 		});
 		return this.client.send(duid, request);
 	}

--- a/src/tests/roborockCommunication/helper/B01VacuumModeResolver.test.ts
+++ b/src/tests/roborockCommunication/helper/B01VacuumModeResolver.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { B01VacuumModeResolver } from '../../../roborockCommunication/helper/B01VacuumModeResolver.js';
 
 const {
-	resolveVacuumMode,
+	resolveQ7VacuumMode,
+	resolveQ10VacuumMode,
 	resolveMopMode,
 	resolveCleanRoute,
 	resolveQ7CleanMode,
@@ -38,15 +39,27 @@ const Q7MopRoute = {
 };
 
 describe('B01VacuumModeResolver', () => {
-	describe('resolveVacuumMode', () => {
+	describe('resolveQ7VacuumMode', () => {
 		it('returns correct mode for each suctionPower', () => {
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.Quiet)).toBe(1);
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.Balanced)).toBe(2);
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.Turbo)).toBe(3);
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.Max)).toBe(4);
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.MaxPlus)).toBe(5);
-			expect(resolveVacuumMode(Q7VacuumSuctionPower.Off)).toBe(0);
-			expect(resolveVacuumMode(99)).toBe(0);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.Quiet)).toBe(1);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.Balanced)).toBe(2);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.Turbo)).toBe(3);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.Max)).toBe(4);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.MaxPlus)).toBe(5);
+			expect(resolveQ7VacuumMode(Q7VacuumSuctionPower.Off)).toBe(0);
+			expect(resolveQ7VacuumMode(99)).toBe(0);
+		});
+	});
+
+	describe('resolveQ10VacuumMode', () => {
+		it('returns correct mode for each suctionPower', () => {
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.Quiet)).toBe(1);
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.Balanced)).toBe(2);
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.Turbo)).toBe(3);
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.Max)).toBe(4);
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.MaxPlus)).toBe(8);
+			expect(resolveQ10VacuumMode(Q7VacuumSuctionPower.Off)).toBe(0);
+			expect(resolveQ10VacuumMode(99)).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- `B01VacuumModeResolver.resolveVacuumMode` always sent wire value `5` (MaxPlus) regardless of device family, but Q10 devices expect `8` — confirmed against the `python-roborock` reference library (`b01_q7_code_mappings.py::SCWindMapping` vs `b01_q10_code_mappings.py::YXFanLevel`).
- Split into `resolveQ7VacuumMode` (unchanged, MaxPlus→5) and `resolveQ10VacuumMode` (fixed, MaxPlus→8), following the existing `resolveQ7CleanMode`/`resolveQ10CleanMode` split pattern in the same file.
- Updated `Q7MessageDispatcher` and `Q10MessageDispatcher` call sites accordingly.
- Fixed `resolveQ10VacuumMode` to reference the generic `VacuumSuctionPower` enum instead of the Q7-specific one (naming correctness, no behavior change).

## Test plan
- [x] Unit tests updated/added for both `resolveQ7VacuumMode` and `resolveQ10VacuumMode` (MaxPlus=8 case for Q10)
- [x] `format:ci` / `lint:fix:ci` / `type-check:ci` / `test:ci` / `precommit:ci` all pass
- [x] Validated live against a real Roborock Q10 (with `enableCleanModeMapping` + `fanMode: MaxPlus`): command sends `suctionPower: 108`, device correctly reports back `108` (MaxPlus) after the fix