### PR TITLE
feat(mqtt): event-driven health monitor + general backoff for reconnects

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -11,9 +11,6 @@ It is version-controlled — commit and push changes so teammates can pull the l
 
 <!-- Patterns and relationships discovered during analysis -->
 
-- Room data (supportedAreas, roomIndexMap) is in-memory only inside `AreaManagementService` private Maps keyed by duid — no file/db persistence.
-- Room name resolution (`getSupportedAreas.ts:109-113`): `iot_name` → lookup by `iot_name_id` → `Unknown Room ${randomInt(1000,9999)}`. B01 path normalizes firmware tokens via `normalizeB01RoomName()`; R2 deterministic fallback deferred.
-- Q7 map fetch: `Q7MessageDispatcher.getRoomMap`/`getRoomMapV2` fire `service.upload_by_maptype` (`get_room_mapping`) with `{ force: 1, map_type: 0 }` — primary-only, no fallback retry; `activeMap` param retained but not sent.
 - `AreaManagementService.clearAll()` wipes all in-memory area data including room names. Fallback room name suffix (`RANDOM_ROOM_MIN=1000`, `MAX=9999`) is non-deterministic — changes every startup.
 - Startup room names: `getRoomMap` enriches raw tuples via `HomeModelMapper.enrichMapRoomDtoFromMapInfo(dto, mapInfoCache)` before `toRoomMapping`; `HomeEntity` uses `storedMapInfo` not `MapInfo.empty()`.
 - `ModeUtils.assertModeChange` (matter.js mode-base) never checks operational state for Run/Clean Mode — only "is newMode supported"; mid-clean mode changes already work with zero guards anywhere in the chain.
@@ -40,14 +37,6 @@ It is version-controlled — commit and push changes so teammates can pull the l
 
 <!-- Architectural and design decisions with rationale -->
 
-- `MatterbridgeServiceAreaServer.selectAreas` (`@matterbridge/core`) unconditionally calls `super.selectAreas(request)` with the ORIGINAL request AFTER our command handler runs, writing `this.state.selectedAreas` directly (bypasses `updateAttribute`). Any empty-input resolution must intercept in `RoborockServiceAreaServer.selectAreas` and forward a RESOLVED request to `super.selectAreas`, not `updateAttribute` from `roborockVacuumCleaner.ts`'s command handler — that write always loses the race.
-- `extra_time` → `estimatedEndTime` removed (Jul 2026); replacement: V1-only opt-in `enableEstimatedEndTime` (default off) + `clean_time`/`clean_percent` linear ETA in `src/share/estimatedEndTime.ts`; B01/Q7/Q10 stay `null`.
-- `robot.homeInFo.activeMapId` inits to `-1` (`deviceConfigurator.ts:105`), only written via B01/Q7 `onActiveMapChanged` — V10/V1 NEVER updates it. `RoomIndexMap.getAreaId(roomId,mapId)` then always misses for V10/V1 multi-map; `getAreaIdV2(roomId)` is the correct fallback.
-- No "currently selected map" Matter attribute exists — Apple Home infers active map from which map's rooms appear first in `supportedAreas`/`selectedAreas` (mirrors `roborockService.ts:350` `buildCleanCommand`).
-- `handleActiveMapChanged` (`serviceAreaHandler.ts:234-275`) has no idle/cleaning guard — unconditionally overwrites `selectedAreas`/`currentArea`/`progress`; only matters if the device reports a genuinely different active map mid-clean.
-- Shared state-update helper pattern (`applyResolvedStateUpdates`, `deviceStateHandler.ts:22-49`): extract identical Promise.all/snapshot/completion blocks into a private async helper; callers keep their own state resolution and return values.
-- `AreaManagementService.supportedRoutines` (routine-as-room, `mapId=999`) is structurally separate from `supportedAreas` — "all rooms of active map" logic from `getSupportedAreas` excludes routines automatically.
-- `homeInFo.activeMapId` alone is unreliable for active-map inference (stays -1 for V10/V1). Fallback order used in `SELECT_AREAS` empty-list handling: Matter `selectedAreas` mapId → `activeMapId` (if not -1) → first `supportedAreas` mapId.
 - `RvcRunMode.ChangeToMode(Idle)` is now handled via `IdleModeHandler` (new, Jul 10 2026) → `roborockService.pauseClean`. `Mapping` deferred: `AbstractMessageDispatcher` (V10/Q7/Q10) has zero mapping/explore-start command.
 - `getSupportedAreas()` (`initialData/getSupportedAreas.ts`) is the single point enforcing "Areas non-null mapId ⇒ supportedMaps non-empty" (Matter `#assertSupportedAreas`). `processValidData` branch always assigns numeric `mapId`; empty `mapInfo.maps` (e.g. `MapInfo.empty()` fallback) previously left `supportedMaps=[]` — fixed via `buildPlaceholderSupportedMaps` (pair, don't null — matches existing `createFallbackArea` convention).
 - V1 currentArea fallback (planned): CLI's `extractNamedRooms`/`roomDisplayName` (`cli/mapListHelpers.ts`) stay CLI-only — runtime resolves `segmentId → areaId` via existing `roomIndexMap.getAreaId`/`getAreaIdV2`, doesn't need room names, so no move/share needed.
@@ -56,6 +45,8 @@ It is version-controlled — commit and push changes so teammates can pull the l
 - Dock→Matter mapping (Jul 2026): default bundle Items 1+2+3+4 in `DockStationStatus.ts` only; Item 3 vs 5 mutually exclusive (full dss vs dustBag-only); codes 32/33/35 as `DockErrorCode` enum; dss priority clearWater→dirty→dustBag→cleanFluid→filter→updown.
 - `progress` reset on start-of-clean (Jul 14, 2026): 3rd trigger added — `handleServiceAreaUpdate` compares stored-vs-current `operationalState` "actively cleaning" classification (Docked/Stopped/Error = not cleaning), NOT raw `CLEANING_STATES` membership (misses `ReturningDock`/`EmptyingDustContainer` detours → false positives). Flag stored in `AreaManagementService` (proxied via `RoborockService`), not a module-level var.
 - Vacuum→Matter mapping (Jul 2026): bundle ideas 2–6 in `VacuumStatus.ts`; export `VACUUM_ERROR_TO_MATTER`; unknown non-zero → `UnableToCompleteOperation`; add `VacuumErrorCode.AutoEmptyDockFanError=33`; 8 semantic refinements per spike answer.md.
+- `MQTTClient` has TWO parallel reconnect mechanisms pre-existing (Jul 2026): `AbstractClient`'s private `connectionBroadcaster`→`ConnectionStateListener` (30s manual reconnect on close/disconnect, `MAX_RETRY_COUNT` cap, self-disables on auth error) is separate from `MQTTClient.onError`'s own `consecutiveAuthErrors` 60-min fixed backoff (`terminateConnection()`+`setTimeout(connect)`, bypasses mqtt.js auto-reconnect via `end(true)`). Any new backoff must reuse the `terminateConnection()`+`setTimeout` idiom, not add a 3rd competing scheduler.
+- `ClientRouter.query()` is the only place request/response timeouts are observable (`clientRouter.ts:101-118`); routes via `request.secure` to `mqttClient` vs local client — health/timeout signals must be guarded by `request.secure` to avoid counting local-client timeouts as MQTT failures.
 
 ## Test Patterns
 

--- a/src/constants/timeouts.ts
+++ b/src/constants/timeouts.ts
@@ -26,6 +26,31 @@ export const RECONNECT_DELAY_MS = 10000;
 export const KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
+ * Consecutive query timeouts before the MQTT health monitor forces a reconnect (mirrors python-roborock TIMEOUT_THRESHOLD).
+ */
+export const HEALTH_TIMEOUT_THRESHOLD = 3;
+
+/**
+ * Minimum time between health-monitor-triggered forced reconnects (mirrors python-roborock RESTART_COOLDOWN, 30 min).
+ */
+export const HEALTH_RESTART_COOLDOWN_MS = 30 * 60 * 1000;
+
+/**
+ * Starting delay for general (non-auth) MQTT backoff reconnects (mirrors python-roborock MIN_BACKOFF_INTERVAL, 10s).
+ */
+export const MIN_BACKOFF_INTERVAL_MS = 10 * 1000;
+
+/**
+ * Cap for general MQTT backoff delay (mirrors python-roborock MAX_BACKOFF_INTERVAL, 6h).
+ */
+export const MAX_BACKOFF_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Multiplier applied to the general MQTT backoff delay on each consecutive failure (mirrors python-roborock BACKOFF_MULTIPLIER).
+ */
+export const BACKOFF_MULTIPLIER = 1.5;
+
+/**
  * Minimum time between verification code requests (15 minutes).
  * Rate limiting for 2FA code generation.
  */

--- a/src/roborockCommunication/mqtt/mqttClient.ts
+++ b/src/roborockCommunication/mqtt/mqttClient.ts
@@ -1,11 +1,19 @@
 import { AnsiLogger, debugStringify } from 'matterbridge/logger';
 import mqtt, { ErrorWithReasonCode, IConnackPacket, ISubscriptionGrant, MqttClient as MqttLibClient } from 'mqtt';
 
-import { KEEPALIVE_INTERVAL_MS } from '../../constants/timeouts.js';
+import {
+	BACKOFF_MULTIPLIER,
+	HEALTH_RESTART_COOLDOWN_MS,
+	HEALTH_TIMEOUT_THRESHOLD,
+	KEEPALIVE_INTERVAL_MS,
+	MAX_BACKOFF_INTERVAL_MS,
+	MIN_BACKOFF_INTERVAL_MS,
+} from '../../constants/timeouts.js';
 import * as CryptoUtils from '../helper/cryptoHelper.js';
 import { MessageContext, RequestMessage, Rriot, UserData } from '../models/index.js';
 import { AbstractClient } from '../routing/abstractClient.js';
 import { ResponseBroadcaster } from '../routing/listeners/responseBroadcaster.js';
+import { MqttHealthMonitor } from './mqttHealthMonitor.js';
 
 export class MQTTClient extends AbstractClient {
 	protected override clientName = 'MQTTClient';
@@ -14,11 +22,14 @@ export class MQTTClient extends AbstractClient {
 	private readonly mqttUsername: string;
 	private readonly mqttPassword: string;
 	private mqttClient: MqttLibClient | undefined = undefined;
-	private keepConnectionAliveInterval: NodeJS.Timeout | undefined = undefined;
 	private connected = false;
 	private isForceReconnecting = false;
 	private consecutiveAuthErrors = 0;
 	private authErrorBackoffTimeout: NodeJS.Timeout | undefined = undefined;
+	private readonly healthMonitor = new MqttHealthMonitor(HEALTH_TIMEOUT_THRESHOLD, HEALTH_RESTART_COOLDOWN_MS);
+	private consecutiveGeneralFailures = 0;
+	private generalBackoffMs = MIN_BACKOFF_INTERVAL_MS;
+	private generalBackoffTimeout: NodeJS.Timeout | undefined = undefined;
 
 	public constructor(
 		logger: AnsiLogger,
@@ -67,8 +78,6 @@ export class MQTTClient extends AbstractClient {
 		this.mqttClient.on('disconnect', this.onDisconnect.bind(this));
 		this.mqttClient.on('offline', this.onOffline.bind(this));
 		this.mqttClient.on('message', this.onMessage.bind(this));
-
-		this.keepConnectionAlive();
 	}
 
 	public override async disconnect(): Promise<void> {
@@ -78,14 +87,14 @@ export class MQTTClient extends AbstractClient {
 		}
 
 		try {
-			if (this.keepConnectionAliveInterval) {
-				clearInterval(this.keepConnectionAliveInterval);
-				this.keepConnectionAliveInterval = undefined;
-			}
-
 			if (this.authErrorBackoffTimeout) {
 				clearTimeout(this.authErrorBackoffTimeout);
 				this.authErrorBackoffTimeout = undefined;
+			}
+
+			if (this.generalBackoffTimeout) {
+				clearTimeout(this.generalBackoffTimeout);
+				this.generalBackoffTimeout = undefined;
 			}
 
 			this.mqttClient.end();
@@ -112,24 +121,52 @@ export class MQTTClient extends AbstractClient {
 		this.logger.debug(`[MQTTClient] sent message to ${duid}`);
 	}
 
-	private keepConnectionAlive(): void {
-		if (this.keepConnectionAliveInterval) {
-			clearInterval(this.keepConnectionAliveInterval);
-			this.keepConnectionAliveInterval.unref();
+	public reportQuerySuccess(): void {
+		this.healthMonitor.onSuccess();
+	}
+
+	public reportQueryTimeout(): void {
+		this.healthMonitor.onTimeout();
+		if (this.healthMonitor.shouldRestart(Date.now())) {
+			this.logger.warn(
+				`[MQTTClient] Health monitor: too many consecutive query timeouts (${this.healthMonitor.getConsecutiveTimeouts()})`,
+			);
+			this.forceReconnect('health monitor: too many consecutive query timeouts');
+			this.healthMonitor.recordRestart(Date.now());
+		}
+	}
+
+	private forceReconnect(reason: string): void {
+		if (this.mqttClient) {
+			this.logger.debug(`[MQTTClient] Force reconnecting: ${reason}`);
+			this.isForceReconnecting = true;
+			this.mqttClient.end();
+			this.mqttClient.reconnect();
+		} else {
+			this.logger.info(`[MQTTClient] Force reconnecting (new connection): ${reason}`);
+			this.connect();
+		}
+	}
+
+	private scheduleGeneralBackoffReconnect(reason: string): void {
+		this.consecutiveGeneralFailures++;
+		const delayMs = this.generalBackoffMs;
+		this.generalBackoffMs = Math.min(this.generalBackoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_INTERVAL_MS);
+
+		if (this.generalBackoffTimeout) {
+			clearTimeout(this.generalBackoffTimeout);
 		}
 
-		// Always do a reconnect because the mqtt sometimes does not response any more
-		this.keepConnectionAliveInterval = setInterval(() => {
-			if (this.mqttClient) {
-				this.logger.debug('[MQTTClient] Force reconnecting to ensure fresh connection');
-				this.isForceReconnecting = true;
-				this.mqttClient.end();
-				this.mqttClient.reconnect();
-			} else {
-				this.logger.info('[MQTTClient] Force reconnecting to ensure fresh connection (new connection)');
-				this.connect();
-			}
-		}, KEEPALIVE_INTERVAL_MS);
+		this.logger.warn(
+			`[MQTTClient] Scheduling general backoff reconnect: ${reason} (delay: ${delayMs}ms, failures: ${this.consecutiveGeneralFailures})`,
+		);
+
+		this.terminateConnection();
+		this.generalBackoffTimeout = setTimeout(() => {
+			this.generalBackoffTimeout = undefined;
+			this.connect();
+		}, delayMs);
+		this.generalBackoffTimeout.unref();
 	}
 
 	private async onConnect(result: IConnackPacket): Promise<void> {
@@ -143,6 +180,13 @@ export class MQTTClient extends AbstractClient {
 
 		this.connected = true;
 		this.consecutiveAuthErrors = 0;
+		this.consecutiveGeneralFailures = 0;
+		this.generalBackoffMs = MIN_BACKOFF_INTERVAL_MS;
+		if (this.generalBackoffTimeout) {
+			clearTimeout(this.generalBackoffTimeout);
+			this.generalBackoffTimeout = undefined;
+		}
+
 		this.logger.info(`[MQTTClient] connected to MQTT broker with result: ${debugStringify(result)}`);
 		this.subscribeToQueue();
 
@@ -205,18 +249,20 @@ export class MQTTClient extends AbstractClient {
 				}, KEEPALIVE_INTERVAL_MS);
 				this.authErrorBackoffTimeout.unref();
 			}
+		} else {
+			this.scheduleGeneralBackoffReconnect(`MQTT connection error: ${errorMessage}`);
 		}
 	}
 
 	private terminateConnection(): void {
-		if (this.keepConnectionAliveInterval) {
-			clearInterval(this.keepConnectionAliveInterval);
-			this.keepConnectionAliveInterval = undefined;
-		}
-
 		if (this.authErrorBackoffTimeout) {
 			clearTimeout(this.authErrorBackoffTimeout);
 			this.authErrorBackoffTimeout = undefined;
+		}
+
+		if (this.generalBackoffTimeout) {
+			clearTimeout(this.generalBackoffTimeout);
+			this.generalBackoffTimeout = undefined;
 		}
 
 		if (this.mqttClient) {
@@ -230,6 +276,7 @@ export class MQTTClient extends AbstractClient {
 	private async onClose(): Promise<void> {
 		if (this.connected && !this.isForceReconnecting) {
 			await this.connectionBroadcaster.onClose(`mqtt-${this.mqttUsername}`);
+			this.scheduleGeneralBackoffReconnect('MQTT connection closed unexpectedly');
 		}
 
 		this.connected = false;
@@ -238,6 +285,7 @@ export class MQTTClient extends AbstractClient {
 	private async onOffline(): Promise<void> {
 		this.connected = false;
 		await this.connectionBroadcaster.onOffline(`mqtt-${this.mqttUsername}`);
+		this.scheduleGeneralBackoffReconnect('MQTT client went offline');
 	}
 
 	private onReconnect(): void {

--- a/src/roborockCommunication/mqtt/mqttHealthMonitor.ts
+++ b/src/roborockCommunication/mqtt/mqttHealthMonitor.ts
@@ -1,0 +1,77 @@
+/**
+ * MQTT health monitor for detecting unresponsive connections.
+ * Tracks consecutive query timeouts and determines when a forced reconnect is needed,
+ * mirroring the python-roborock health_manager.py concept.
+ *
+ * @module roborockCommunication/mqtt/mqttHealthMonitor
+ */
+
+/**
+ * Monitors MQTT query health and determines when reconnection is needed.
+ * Tracks consecutive timeouts and enforces a cooldown between restart attempts.
+ */
+export class MqttHealthMonitor {
+	private consecutiveTimeouts = 0;
+	private lastRestartAt: number | undefined;
+
+	/**
+	 * Creates a new MQTT health monitor.
+	 * @param timeoutThreshold - Number of consecutive timeouts before a restart is considered
+	 * @param restartCooldownMs - Minimum milliseconds between restart attempts
+	 */
+	public constructor(
+		private readonly timeoutThreshold: number,
+		private readonly restartCooldownMs: number,
+	) {}
+
+	/**
+	 * Records a successful query response and resets the timeout counter.
+	 */
+	public onSuccess(): void {
+		this.consecutiveTimeouts = 0;
+	}
+
+	/**
+	 * Records a query timeout and increments the consecutive timeout counter.
+	 */
+	public onTimeout(): void {
+		this.consecutiveTimeouts += 1;
+	}
+
+	/**
+	 * Determines whether a restart should be attempted based on current state.
+	 * Returns true only if enough timeouts have accumulated AND sufficient time has passed since the last restart.
+	 *
+	 * @param now - Current timestamp in milliseconds
+	 * @returns true if a reconnect should be attempted, false otherwise
+	 */
+	public shouldRestart(now: number): boolean {
+		if (this.consecutiveTimeouts < this.timeoutThreshold) {
+			return false;
+		}
+
+		if (this.lastRestartAt === undefined) {
+			return true;
+		}
+
+		return now - this.lastRestartAt >= this.restartCooldownMs;
+	}
+
+	/**
+	 * Records that a restart was attempted and resets the timeout counter.
+	 * Should be called after a reconnect is initiated.
+	 *
+	 * @param now - Current timestamp in milliseconds
+	 */
+	public recordRestart(now: number): void {
+		this.lastRestartAt = now;
+		this.consecutiveTimeouts = 0;
+	}
+
+	/**
+	 * Returns the current consecutive timeout count for testing/debugging purposes.
+	 */
+	public getConsecutiveTimeouts(): number {
+		return this.consecutiveTimeouts;
+	}
+}

--- a/src/roborockCommunication/routing/clientRouter.ts
+++ b/src/roborockCommunication/routing/clientRouter.ts
@@ -108,8 +108,15 @@ export class ClientRouter implements Client {
 		this.broadcasterFactory.register(listener);
 		try {
 			await this.send(duid, request);
-			return await listener.waitFor();
+			const result = await listener.waitFor();
+			if (request.secure) {
+				this.mqttClient.reportQuerySuccess();
+			}
+			return result;
 		} catch (error) {
+			if (request.secure) {
+				this.mqttClient.reportQueryTimeout();
+			}
 			this.logger.error(error instanceof Error ? error.message : String(error));
 			return undefined;
 		} finally {

--- a/src/tests/roborockCommunication/broadcast/client/MQTTClient.test.ts
+++ b/src/tests/roborockCommunication/broadcast/client/MQTTClient.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 
 import { MessageContext, RequestMessage } from '../../../../roborockCommunication/models/index.js';
 import { MQTTClient } from '../../../../roborockCommunication/mqtt/mqttClient.js';
+import { MqttHealthMonitor } from '../../../../roborockCommunication/mqtt/mqttHealthMonitor.js';
 import { ConnectionBroadcaster } from '../../../../roborockCommunication/routing/listeners/connectionBroadcaster.js';
 import { V1ResponseBroadcaster } from '../../../../roborockCommunication/routing/listeners/v1ResponseBroadcaster.js';
 import { asPartial, asType, createMockLogger } from '../../../helpers/testUtils.js';
@@ -49,12 +50,9 @@ describe('MQTTClient (additional)', () => {
 	it('connect calls mqtt.connect and registers event handlers', () => {
 		const mockMqttClient: any = { on: vi.fn(), end: vi.fn(), reconnect: vi.fn(), publish: vi.fn(), subscribe: vi.fn() };
 
-		// prevent keepAlive timer from running
 		const spyConnect = vi.spyOn(mqtt, 'connect').mockImplementation(() => asType<any>(mockMqttClient));
 
 		const client = new MQTTClient(logger, context, userdata, responseBroadcaster);
-
-		client['keepConnectionAlive'] = vi.fn();
 
 		client.connect();
 
@@ -89,7 +87,6 @@ describe('MQTTClient (additional)', () => {
 
 		const client = new MQTTClient(logger, context, userdata, responseBroadcaster);
 
-		client['keepConnectionAlive'] = vi.fn();
 		client['mqttClient'] = mockMqttClient;
 		client['connected'] = true;
 
@@ -164,7 +161,7 @@ describe('MQTTClient', () => {
 		globalThis.mockConnect.mockReturnValue(client);
 	});
 
-	function createMQTTClient() {
+	function createMQTTClient(overrideHealthMonitor?: any) {
 		class TestMQTTClient extends MQTTClient {
 			constructor() {
 				super(logger, context, userdata, responseBroadcaster);
@@ -197,6 +194,13 @@ describe('MQTTClient', () => {
 			writable: true,
 		});
 
+		if (overrideHealthMonitor) {
+			Object.defineProperty(mqttClient, 'healthMonitor', {
+				value: overrideHealthMonitor,
+				writable: true,
+			});
+		}
+
 		createdClients.push(mqttClient);
 		return mqttClient;
 	}
@@ -205,8 +209,11 @@ describe('MQTTClient', () => {
 		// Clean up any MQTT clients to prevent timer leaks
 		for (const mqttClient of createdClients) {
 			try {
-				if (mqttClient.keepConnectionAliveInterval) {
-					clearInterval(mqttClient.keepConnectionAliveInterval);
+				if (mqttClient.generalBackoffTimeout) {
+					clearTimeout(mqttClient.generalBackoffTimeout);
+				}
+				if (mqttClient.authErrorBackoffTimeout) {
+					clearTimeout(mqttClient.authErrorBackoffTimeout);
 				}
 				if (mqttClient.mqttClient) {
 					// Force the client to null to prevent reconnect attempts
@@ -400,58 +407,29 @@ describe('MQTTClient', () => {
 		expect(typeof actualClient?.subscribe).toBe('function');
 	});
 
-	it('keepConnectionAlive should setup interval that reconnects client', () => {
-		vi.useFakeTimers();
+	it('forceReconnect should end and reconnect existing mqttClient', () => {
 		const mqttClient = createMQTTClient();
 		mqttClient['mqttClient'] = client;
 		mqttClient['connected'] = true;
-		mqttClient['keepConnectionAlive']();
 
-		expect(mqttClient['keepConnectionAliveInterval']).toBeDefined();
-		// Fast-forward time by 60 minutes to trigger the interval callback
-		vi.advanceTimersByTime(60 * 60 * 1000);
+		mqttClient['forceReconnect']('test reason');
 
-		expect(logger.debug).toHaveBeenCalledWith('[MQTTClient] Force reconnecting to ensure fresh connection');
-
-		// Clean up
-		clearInterval(mqttClient['keepConnectionAliveInterval']);
-		vi.useRealTimers();
+		expect(mqttClient['isForceReconnecting']).toBe(true);
+		expect(client.end).toHaveBeenCalled();
+		expect(client.reconnect).toHaveBeenCalled();
+		expect(logger.debug).toHaveBeenCalledWith('[MQTTClient] Force reconnecting: test reason');
 	});
 
-	it('keepConnectionAlive should call connect if mqttClient is undefined', () => {
-		vi.useFakeTimers();
+	it('forceReconnect should call connect if mqttClient is undefined', () => {
 		const mqttClient = createMQTTClient();
 		const connectSpy = vi.spyOn(mqttClient, 'connect');
 		mqttClient['mqttClient'] = undefined;
 		mqttClient['connected'] = false;
-		mqttClient['keepConnectionAlive']();
 
-		// Fast-forward time by 60 minutes to trigger the interval callback
-		vi.advanceTimersByTime(60 * 60 * 1000);
+		mqttClient['forceReconnect']('test reason');
 
 		expect(connectSpy).toHaveBeenCalled();
-
-		// Clean up
-		clearInterval(mqttClient['keepConnectionAliveInterval']);
-		vi.useRealTimers();
-	});
-
-	it('keepConnectionAlive should clear existing interval before setting new one', () => {
-		vi.useFakeTimers();
-		const mqttClient = createMQTTClient();
-		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
-
-		// Set initial interval
-		mqttClient['keepConnectionAlive']();
-		const firstInterval = mqttClient['keepConnectionAliveInterval'];
-
-		// Call again to clear and reset
-		mqttClient['keepConnectionAlive']();
-		expect(clearIntervalSpy).toHaveBeenCalledWith(firstInterval);
-
-		// Clean up
-		clearInterval(mqttClient['keepConnectionAliveInterval']);
-		vi.useRealTimers();
+		expect(logger.info).toHaveBeenCalledWith('[MQTTClient] Force reconnecting (new connection): test reason');
 	});
 
 	it('disconnect should return early if not connected', async () => {
@@ -494,15 +472,13 @@ describe('MQTTClient', () => {
 		expect(mqttClient['connectionBroadcaster'].onConnected).toHaveBeenCalledWith('mqtt-c6d6afb9');
 	});
 
-	it('should NOT broadcast onClose or onConnected when keepConnectionAlive forces reconnect', async () => {
-		vi.useFakeTimers();
+	it('should NOT broadcast onClose or onConnected when forceReconnect triggers the close', async () => {
 		const mqttClient = createMQTTClient();
 		mqttClient['mqttClient'] = client;
 		mqttClient['connected'] = true;
 		mqttClient['subscribeToQueue'] = vi.fn();
 
-		mqttClient['keepConnectionAlive']();
-		vi.advanceTimersByTime(60 * 60 * 1000);
+		mqttClient['forceReconnect']('test reason');
 
 		expect(mqttClient['isForceReconnecting']).toBe(true);
 
@@ -513,9 +489,6 @@ describe('MQTTClient', () => {
 		expect(mqttClient['connectionBroadcaster'].onConnected).not.toHaveBeenCalled();
 
 		expect(mqttClient['isForceReconnecting']).toBe(false);
-
-		clearInterval(mqttClient['keepConnectionAliveInterval']);
-		vi.useRealTimers();
 	});
 
 	it('onOffline should set connected to false and call onOffline', async () => {
@@ -607,13 +580,13 @@ describe('MQTTClient', () => {
 		const mqttClient = createMQTTClient();
 		mqttClient['mqttClient'] = client;
 		mqttClient['connected'] = true;
-		mqttClient['keepConnectionAliveInterval'] = setInterval(() => {}, 1000);
 		mqttClient['authErrorBackoffTimeout'] = setTimeout(() => {}, 1000);
+		mqttClient['generalBackoffTimeout'] = setTimeout(() => {}, 1000);
 
 		mqttClient['terminateConnection']();
 
-		expect(mqttClient['keepConnectionAliveInterval']).toBeUndefined();
 		expect(mqttClient['authErrorBackoffTimeout']).toBeUndefined();
+		expect(mqttClient['generalBackoffTimeout']).toBeUndefined();
 		expect(client.end).toHaveBeenCalledWith(true);
 		expect(mqttClient['mqttClient']).toBeUndefined();
 		expect(mqttClient['connected']).toBe(false);
@@ -623,8 +596,8 @@ describe('MQTTClient', () => {
 		const mqttClient = createMQTTClient();
 		mqttClient['mqttClient'] = client;
 		mqttClient['connected'] = true;
-		mqttClient['keepConnectionAliveInterval'] = undefined;
 		mqttClient['authErrorBackoffTimeout'] = undefined;
+		mqttClient['generalBackoffTimeout'] = undefined;
 
 		mqttClient['terminateConnection']();
 
@@ -640,28 +613,6 @@ describe('MQTTClient', () => {
 		mqttClient['terminateConnection']();
 
 		expect(mqttClient['connected']).toBe(false);
-	});
-
-	it('keepConnectionAlive should reconnect when client does not exists', () => {
-		vi.useFakeTimers();
-		const mqttClient = createMQTTClient();
-		const connectSpy = vi.spyOn(mqttClient, 'connect');
-		const originalClient = mqttClient['mqttClient'];
-		mqttClient['mqttClient'] = undefined;
-		mqttClient['connected'] = false;
-		mqttClient['keepConnectionAlive']();
-
-		// Fast-forward time by 60 minutes to trigger the interval callback
-		vi.advanceTimersByTime(60 * 60 * 1000);
-
-		expect(connectSpy).toHaveBeenCalled();
-		expect(logger.info).toHaveBeenCalledWith(
-			'[MQTTClient] Force reconnecting to ensure fresh connection (new connection)',
-		);
-
-		// Clean up
-		clearInterval(mqttClient['keepConnectionAliveInterval']);
-		vi.useRealTimers();
 	});
 
 	it('onConnect should return early if result is falsy', async () => {
@@ -696,17 +647,6 @@ describe('MQTTClient', () => {
 		expect(logger.error).toHaveBeenCalledWith('[MQTTClient] cannot subscribe, client not connected');
 	});
 
-	it('disconnect should clear keepConnectionAliveInterval', async () => {
-		const mqttClient = createMQTTClient();
-		mqttClient['mqttClient'] = client;
-		mqttClient['connected'] = true;
-		mqttClient['keepConnectionAliveInterval'] = setInterval(() => {}, 1000);
-
-		await mqttClient.disconnect();
-
-		expect(mqttClient['keepConnectionAliveInterval']).toBeUndefined();
-	});
-
 	it('disconnect should clear authErrorBackoffTimeout', async () => {
 		const mqttClient = createMQTTClient();
 		mqttClient['mqttClient'] = client;
@@ -731,5 +671,254 @@ describe('MQTTClient', () => {
 		});
 		await mqttClient['onMessage']('topic/duid', Buffer.from('msg'));
 		expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('unable to process message'));
+	});
+
+	describe('Health Monitor Integration', () => {
+		it('reportQuerySuccess should reset consecutive timeouts', () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['healthMonitor'].onTimeout();
+			mqttClient['healthMonitor'].onTimeout();
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(2);
+
+			mqttClient.reportQuerySuccess();
+
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(0);
+		});
+
+		it('reportQueryTimeout should increment timeout counter', () => {
+			const mqttClient = createMQTTClient();
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(0);
+
+			mqttClient.reportQueryTimeout();
+
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(1);
+		});
+
+		it('reportQueryTimeout should not forceReconnect when threshold not reached', () => {
+			const mqttClient = createMQTTClient();
+			const forceReconnectSpy = vi.spyOn(mqttClient as any, 'forceReconnect');
+
+			mqttClient.reportQueryTimeout();
+			mqttClient.reportQueryTimeout();
+
+			expect(forceReconnectSpy).not.toHaveBeenCalled();
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(2);
+		});
+
+		it('reportQueryTimeout should forceReconnect when threshold is reached', () => {
+			const mqttClient = createMQTTClient();
+			const forceReconnectSpy = vi.spyOn(mqttClient as any, 'forceReconnect');
+
+			mqttClient.reportQueryTimeout();
+			mqttClient.reportQueryTimeout();
+			mqttClient.reportQueryTimeout();
+
+			expect(forceReconnectSpy).toHaveBeenCalledWith('health monitor: too many consecutive query timeouts');
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Health monitor: too many consecutive query timeouts'),
+			);
+			// After recordRestart, counter is reset
+			expect(mqttClient['healthMonitor'].getConsecutiveTimeouts()).toBe(0);
+		});
+
+		it('reportQueryTimeout should respect cooldown after health-triggered restart', () => {
+			vi.useFakeTimers();
+			const testMonitor = new MqttHealthMonitor(3, 500); // 500ms cooldown for testing
+			const mqttClient = createMQTTClient(testMonitor);
+			const forceReconnectSpy = vi.spyOn(mqttClient as any, 'forceReconnect');
+
+			// First batch of timeouts triggers restart
+			for (let i = 0; i < 3; i++) mqttClient.reportQueryTimeout();
+			expect(forceReconnectSpy).toHaveBeenCalledTimes(1);
+
+			// Immediately try again - should not trigger due to cooldown
+			vi.advanceTimersByTime(100);
+			for (let i = 0; i < 3; i++) mqttClient.reportQueryTimeout();
+			expect(forceReconnectSpy).toHaveBeenCalledTimes(1); // Still just 1
+
+			// After cooldown expires, should trigger again
+			vi.advanceTimersByTime(400); // Now 500ms has passed
+			for (let i = 0; i < 3; i++) mqttClient.reportQueryTimeout();
+			expect(forceReconnectSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('General Backoff Integration', () => {
+		it('onClose should schedule general backoff when connected and not force reconnecting', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['connected'] = true;
+			mqttClient['isForceReconnecting'] = false;
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onClose']();
+
+			expect(scheduleGeneralBackoffSpy).toHaveBeenCalledWith('MQTT connection closed unexpectedly');
+		});
+
+		it('onClose should not schedule backoff when isForceReconnecting is true', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['connected'] = true;
+			mqttClient['isForceReconnecting'] = true;
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onClose']();
+
+			expect(scheduleGeneralBackoffSpy).not.toHaveBeenCalled();
+		});
+
+		it('onClose should not schedule backoff when not connected', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['connected'] = false;
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onClose']();
+
+			expect(scheduleGeneralBackoffSpy).not.toHaveBeenCalled();
+		});
+
+		it('onOffline should always schedule general backoff', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['connected'] = true;
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onOffline']();
+
+			expect(scheduleGeneralBackoffSpy).toHaveBeenCalledWith('MQTT client went offline');
+		});
+
+		it('onError should schedule general backoff for non-auth errors', async () => {
+			const mqttClient = createMQTTClient();
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onError'](new Error('Connection lost'));
+
+			expect(scheduleGeneralBackoffSpy).toHaveBeenCalledWith(expect.stringContaining('MQTT connection error'));
+		});
+
+		it('onError should not schedule general backoff for auth errors', async () => {
+			const mqttClient = createMQTTClient();
+			const scheduleGeneralBackoffSpy = vi.spyOn(mqttClient as any, 'scheduleGeneralBackoffReconnect');
+
+			await mqttClient['onError'](asPartial<ErrorWithReasonCode>({ code: 5 }));
+
+			expect(scheduleGeneralBackoffSpy).not.toHaveBeenCalled();
+		});
+
+		it('scheduleGeneralBackoffReconnect should compute exponential backoff delay', async () => {
+			vi.useFakeTimers();
+			const mqttClient = createMQTTClient();
+			mqttClient['mqttClient'] = client;
+			const connectSpy = vi.spyOn(mqttClient, 'connect');
+
+			const { MIN_BACKOFF_INTERVAL_MS, BACKOFF_MULTIPLIER, MAX_BACKOFF_INTERVAL_MS } =
+				await import('../../../../constants/timeouts.js');
+
+			// First call
+			mqttClient['scheduleGeneralBackoffReconnect']('error 1');
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`delay: ${MIN_BACKOFF_INTERVAL_MS}ms`));
+
+			// Advance and trigger
+			vi.advanceTimersByTime(MIN_BACKOFF_INTERVAL_MS + 100);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			connectSpy.mockClear();
+
+			// Second call (exponential increase)
+			const expectedDelay = Math.min(MIN_BACKOFF_INTERVAL_MS * BACKOFF_MULTIPLIER, MAX_BACKOFF_INTERVAL_MS);
+			mqttClient['scheduleGeneralBackoffReconnect']('error 2');
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`delay: ${Math.floor(expectedDelay)}ms`));
+
+			vi.useRealTimers();
+		});
+
+		it('scheduleGeneralBackoffReconnect should clear pre-existing timeout', () => {
+			vi.useFakeTimers();
+			const mqttClient = createMQTTClient();
+			mqttClient['mqttClient'] = client;
+
+			const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+			mqttClient['scheduleGeneralBackoffReconnect']('error 1');
+			const firstTimeout = mqttClient['generalBackoffTimeout'];
+
+			mqttClient['scheduleGeneralBackoffReconnect']('error 2');
+
+			expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimeout);
+
+			vi.useRealTimers();
+		});
+
+		it('onConnect should reset general backoff state', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['consecutiveGeneralFailures'] = 5;
+			mqttClient['generalBackoffMs'] = 30000;
+			mqttClient['generalBackoffTimeout'] = setTimeout(() => {}, 1000);
+
+			const { MIN_BACKOFF_INTERVAL_MS } = await import('../../../../constants/timeouts.js');
+
+			await mqttClient['onConnect'](asType<IConnackPacket>({}));
+
+			expect(mqttClient['consecutiveGeneralFailures']).toBe(0);
+			expect(mqttClient['generalBackoffMs']).toBe(MIN_BACKOFF_INTERVAL_MS);
+			expect(mqttClient['generalBackoffTimeout']).toBeUndefined();
+		});
+
+		it('terminateConnection should clear generalBackoffTimeout', () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['generalBackoffTimeout'] = setTimeout(() => {}, 1000);
+			mqttClient['mqttClient'] = client;
+
+			mqttClient['terminateConnection']();
+
+			expect(mqttClient['generalBackoffTimeout']).toBeUndefined();
+		});
+
+		it('disconnect should clear generalBackoffTimeout', async () => {
+			const mqttClient = createMQTTClient();
+			mqttClient['mqttClient'] = client;
+			mqttClient['connected'] = true;
+			mqttClient['generalBackoffTimeout'] = setTimeout(() => {}, 1000);
+
+			await mqttClient.disconnect();
+
+			expect(mqttClient['generalBackoffTimeout']).toBeUndefined();
+		});
+
+		it('scheduleGeneralBackoffReconnect should call terminateConnection before scheduling reconnect', () => {
+			vi.useFakeTimers();
+			const mqttClient = createMQTTClient();
+			const terminateSpy = vi.spyOn(mqttClient as any, 'terminateConnection');
+
+			mqttClient['scheduleGeneralBackoffReconnect']('test error');
+
+			expect(terminateSpy).toHaveBeenCalled();
+
+			vi.useRealTimers();
+		});
+	});
+
+	describe('Re-entrant onClose from forceReconnect', () => {
+		it('should handle re-entrant onClose when forceReconnect calls mqttClient.end()', async () => {
+			vi.useFakeTimers();
+			const mqttClient = createMQTTClient();
+			mqttClient['mqttClient'] = client;
+			mqttClient['connected'] = true;
+
+			// Call forceReconnect which sets isForceReconnecting and calls client.end()
+			mqttClient['forceReconnect']('test reason');
+
+			expect(mqttClient['isForceReconnecting']).toBe(true);
+
+			// Simulate the mqtt client firing the close event from end()
+			await mqttClient['onClose']();
+
+			// Verify that onClose did not broadcast because isForceReconnecting is true
+			expect(mqttClient['connectionBroadcaster'].onClose).not.toHaveBeenCalled();
+
+			// Verify that scheduleGeneralBackoffReconnect was NOT called from this onClose
+			expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Scheduling general backoff reconnect'));
+
+			vi.useRealTimers();
+		});
 	});
 });

--- a/src/tests/roborockCommunication/broadcast/clientRouter.test.ts
+++ b/src/tests/roborockCommunication/broadcast/clientRouter.test.ts
@@ -47,6 +47,8 @@ describe('ClientRouter', () => {
 			isConnected: vi.fn().mockReturnValue(true),
 			connect: vi.fn(),
 			disconnect: vi.fn(),
+			reportQuerySuccess: vi.fn(),
+			reportQueryTimeout: vi.fn(),
 		};
 
 		mockLocalNetworkClient = {

--- a/src/tests/roborockCommunication/mqtt/mqttHealthMonitor.test.ts
+++ b/src/tests/roborockCommunication/mqtt/mqttHealthMonitor.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MqttHealthMonitor } from '../../../roborockCommunication/mqtt/mqttHealthMonitor.js';
+
+describe('MqttHealthMonitor', () => {
+	const SMALL_THRESHOLD = 3;
+	const SMALL_COOLDOWN_MS = 1000;
+
+	let monitor: MqttHealthMonitor;
+
+	beforeEach(() => {
+		monitor = new MqttHealthMonitor(SMALL_THRESHOLD, SMALL_COOLDOWN_MS);
+	});
+
+	describe('onSuccess', () => {
+		it('should reset consecutiveTimeouts to 0 after prior timeouts were recorded', () => {
+			// Arrange
+			monitor.onTimeout();
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(2);
+
+			// Act
+			monitor.onSuccess();
+
+			// Assert
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+		});
+
+		it('should reset to 0 even if no prior timeouts', () => {
+			// Act
+			monitor.onSuccess();
+
+			// Assert
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+		});
+	});
+
+	describe('onTimeout', () => {
+		it('should increment consecutiveTimeouts by 1 each call', () => {
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(1);
+
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(2);
+
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(3);
+		});
+	});
+
+	describe('shouldRestart', () => {
+		it('should return false when consecutiveTimeouts < timeoutThreshold', () => {
+			const now = 1000;
+
+			monitor.onTimeout(); // count = 1
+			expect(monitor.shouldRestart(now)).toBe(false);
+
+			monitor.onTimeout(); // count = 2
+			expect(monitor.shouldRestart(now)).toBe(false);
+		});
+
+		it('should return true when consecutiveTimeouts >= timeoutThreshold and no prior restart', () => {
+			const now = 1000;
+
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout(); // count = 3 (meets threshold)
+
+			expect(monitor.shouldRestart(now)).toBe(true);
+		});
+
+		it('should return false when threshold is met but cooldown not yet elapsed', () => {
+			const now = 1000;
+
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout(); // count = 3
+
+			expect(monitor.shouldRestart(now)).toBe(true);
+
+			// Record the restart
+			monitor.recordRestart(now);
+
+			// Call shouldRestart before cooldown elapses
+			const beforeCooldown = now + SMALL_COOLDOWN_MS - 1;
+			expect(monitor.shouldRestart(beforeCooldown)).toBe(false);
+		});
+
+		it('should return true again once cooldown has elapsed and timeouts re-accumulate', () => {
+			const now = 1000;
+
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout(); // count = 3
+
+			monitor.recordRestart(now); // resets count to 0, cooldown starts at `now`
+
+			// New timeouts accumulate again after the restart
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout(); // count = 3 again
+
+			// Exactly at cooldown time
+			const exactCooldown = now + SMALL_COOLDOWN_MS;
+			expect(monitor.shouldRestart(exactCooldown)).toBe(true);
+
+			// After cooldown time
+			const afterCooldown = now + SMALL_COOLDOWN_MS + 1;
+			expect(monitor.shouldRestart(afterCooldown)).toBe(true);
+		});
+
+		it('should handle multiple restart cycles with cooldown', () => {
+			const now = 1000;
+
+			// First cycle
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+			expect(monitor.shouldRestart(now)).toBe(true);
+
+			monitor.recordRestart(now);
+			expect(monitor.shouldRestart(now + 500)).toBe(false); // Within cooldown
+
+			// Second cycle (after cooldown, timeouts accumulate again)
+			const now2 = now + SMALL_COOLDOWN_MS;
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+			expect(monitor.shouldRestart(now2)).toBe(true);
+		});
+	});
+
+	describe('recordRestart', () => {
+		it('should set lastRestartAt and reset consecutiveTimeouts to 0', () => {
+			const now = 1000;
+
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(3);
+
+			monitor.recordRestart(now);
+
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+			// Verify we can't restart again without cooldown passing
+			expect(monitor.shouldRestart(now)).toBe(false);
+		});
+
+		it('should update lastRestartAt on subsequent calls', () => {
+			const now1 = 1000;
+			const now2 = 2000;
+
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+
+			monitor.recordRestart(now1);
+			expect(monitor.shouldRestart(now1 + 500)).toBe(false); // Cooldown from now1
+
+			// Fast forward and trigger timeouts again
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+
+			monitor.recordRestart(now2);
+			// Cooldown now applies from now2, not now1
+			expect(monitor.shouldRestart(now2 + 500)).toBe(false);
+			// now1's cooldown window would have passed, but lastRestartAt is now2, so now2's cooldown still applies
+			expect(monitor.shouldRestart(now1 + SMALL_COOLDOWN_MS)).toBe(false);
+
+			// Once new timeouts accumulate again, now2's cooldown boundary applies
+			monitor.onTimeout();
+			monitor.onTimeout();
+			monitor.onTimeout();
+			expect(monitor.shouldRestart(now2 + SMALL_COOLDOWN_MS)).toBe(true);
+		});
+	});
+
+	describe('getConsecutiveTimeouts', () => {
+		it('should return current timeout count', () => {
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(1);
+
+			monitor.onTimeout();
+			expect(monitor.getConsecutiveTimeouts()).toBe(2);
+
+			monitor.onSuccess();
+			expect(monitor.getConsecutiveTimeouts()).toBe(0);
+		});
+	});
+});

--- a/workspace/claude_history.md
+++ b/workspace/claude_history.md
@@ -1,5 +1,19 @@
 # Claude History
 
+## 2026-07-18 — Event-driven MQTT health monitoring + general backoff
+
+**Task:** Replace `MQTTClient`'s blind unconditional hourly force-reconnect (`keepConnectionAlive`) with an event-driven health monitor, and add exponential backoff for general (non-auth) MQTT errors/closes/offline events. Based on research into python-roborock's `HealthManager` concept (`workspace/mqtt-disconnect-recovery-reference/answer.md`, via `/ref-idea`).
+
+**Changes:**
+
+- `src/roborockCommunication/mqtt/mqttHealthMonitor.ts` (new) — `MqttHealthMonitor` class tracking consecutive query timeouts; `shouldRestart()` gated by both a timeout threshold and a restart cooldown.
+- `src/roborockCommunication/mqtt/mqttClient.ts` — removed `keepConnectionAlive()`/`keepConnectionAliveInterval`; added `reportQuerySuccess()`/`reportQueryTimeout()` (public), `forceReconnect()`, `scheduleGeneralBackoffReconnect()` (general exponential backoff, 10s→6h, ×1.5), wired into `onClose`/`onOffline`/`onError` (non-auth branch)/`onConnect` reset/`terminateConnection`/`disconnect` cleanup.
+- `src/roborockCommunication/routing/clientRouter.ts` — `query()` reports success/timeout to `mqttClient`, guarded by `request.secure` so local-client queries never affect MQTT health state.
+- `src/constants/timeouts.ts` — added `HEALTH_TIMEOUT_THRESHOLD`, `HEALTH_RESTART_COOLDOWN_MS`, `MIN_BACKOFF_INTERVAL_MS`, `MAX_BACKOFF_INTERVAL_MS`, `BACKOFF_MULTIPLIER`.
+- `src/tests/roborockCommunication/mqtt/mqttHealthMonitor.test.ts` (new), `src/tests/roborockCommunication/broadcast/client/MQTTClient.test.ts`, `src/tests/roborockCommunication/broadcast/clientRouter.test.ts` — test coverage for the above.
+
+**Outcome:** Pass (reviewed and approved; all four verification gates pass: format:ci, lint:fix:ci, type-check:ci, test:ci). Built in worktree `mqtt-reconnect-health-backoff`, PR to `develop` pending.
+
 ## 2026-07-14 — Reset ServiceArea.progress on clean start (third trigger)
 
 **Task:** Add third trigger for resetting `ServiceArea.progress` per-room state when vacuum starts new clean; detect genuine Docked/Stopped/Error → actively-cleaning operationalState transitions using `lastActivelyCleaningState` flag to avoid false positives on mid-clean detours.

--- a/workspace/to_do.md
+++ b/workspace/to_do.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- [x] Event-driven MQTT health monitoring + general exponential backoff — replaces blind hourly `keepConnectionAlive` force-reconnect; ported python-roborock's `HealthManager` concept. All gates pass; PR to `develop` pending.
 - [x] Release candidate `1.1.7-rc04` created
 - [x] Fix `ChargingError` (status code 9) to properly set `operationalError = FailedToFindChargingDock`
 - [x] Investigate feature gaps (reference vs current plugin) — gaps analysis complete


### PR DESCRIPTION
## Summary
- Replace `MQTTClient`'s blind unconditional hourly force-reconnect (`keepConnectionAlive`) with an event-driven `MqttHealthMonitor` that tracks consecutive query timeouts (fed from `ClientRouter.query()`, guarded by `request.secure`) and only forces a reconnect after a threshold of consecutive timeouts is hit, respecting a cooldown between forced restarts.
- Add exponential backoff (10s → 6h, ×1.5) for general (non-auth) MQTT errors/closes/offline events, mirroring the existing auth-error-specific backoff.
- Based on research into python-roborock's `HealthManager` concept (see `workspace/mqtt-disconnect-recovery-reference/answer.md`, produced via `/ref-idea`).

## Test plan
- [x] `format:ci` pass
- [x] `lint:fix:ci` pass
- [x] `type-check:ci` pass
- [x] `test:ci` pass (new `MqttHealthMonitor` unit tests, updated `MQTTClient`/`ClientRouter` tests)
- [x] Reviewed against plan.md — plan conformance and constraint compliance confirmed (no changes to `connectionStateListener.ts`, `LocalNetworkClient`, or resubscribe-on-reconnect behavior; no second polling timer introduced)