### PR TITLE
fix(error-code): report error-clear transitions to Matter controller

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -59,7 +59,6 @@ It is version-controlled — commit and push changes so teammates can pull the l
 
 ## Test Patterns
 
-- **DockStationStatus tests:** `createDockStatus({ field: ERR })` helper with `OK`/`ERR` constants; `it.each` for `parseDockErrorCode` (baseline + 32/33/35) and single-field dss mappings; priority scenarios + `dss=149`/`dss=2729` fixtures for `hasError`/`getMatterOperationalError`.
 - **VacuumStatus tests:** `it.each` full `VACUUM_ERROR_TO_MATTER` table in `src/tests/model/VacuumStatus.test.ts`; unknown `999`/`47` → `UnableToCompleteOperation`; `hasError` for None/unknown/33; `VACUUM_ERROR_TO_MATTER.size` vs enum count. Slim semantic groups in `getOperationalStates.test.ts`.
 - **CLI command tests (`src/tests/cli/`):** mock module boundaries via `vi.mock` with relative `.js` paths, static-import after the mocks. Class constructor mocks need a real `function` (not arrow) in `mockImplementation` or `new` throws.
 - **AreaManagementService.resolveInitialAreas tests:** calls `getMapInfo` then `getRoomMap`, catches errors without throwing. Verify call order with `mock.invocationCallOrder`, error logging with `logger.error`.
@@ -69,12 +68,12 @@ It is version-controlled — commit and push changes so teammates can pull the l
 - **computeAreaEstimatedTime tests:** pure helper returning raw remaining seconds (no `now +`); `25%/60` → `180`; `100%` → `0`; bounds 5–100%; `cleanPercent=undefined` → `null`. Import from `src/share/estimatedEndTime.js`.
 - **ModeHandler tests (IdleModeHandler):** test `canHandle(mode, activity)` returns true only for target activity (Idle), false for others (Cleaning/Mapping/unknown). Integration: add tests to `behaviorConfig.test.ts` that call `registry.handle(duid, mode, activity, context)` and verify `roborockService` method + logger call; run on both DefaultBehavior and BehaviorSmart configs.
 - **RoborockServiceAreaServer.selectAreas override tests:** spy on parent prototype's selectAreas via `vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(server)), 'selectAreas')` and mock its response to avoid deep matterbridge machinery; verify override calls `device.resolveAllRoomsForActiveMap()` for empty input, `device.trySwitchMap(areas)` for non-empty input, forwards resolved/original request to super with correct arguments.
+- **Status listener error-code tests (V1StatusListener, handleHomeDataMessage):** listener fires `onError` whenever error-related field is _defined_ (including 0/None), not only non-zero; test three cases: payload with None/0 codes, field-absent (no call), sequential error→clear (both called). For home-data, `updateRobotWithPayload(ErrorOccurred)` only if errorCode defined; missing field never dispatches.
 
 ## Common Pitfalls
 
 <!-- Things to avoid — bugs found, anti-patterns, footguns -->
 
-- `buildBehaviorConfig(model, featureSet?, newFeatureSet?)` caches by model key only — acceptable (same model → same feature set); include a feature hash in the key if per-feature caching is ever needed.
 - `decodeFeatureSet` returns all-false on invalid `featureSet` (try/catch around `BigInt()`); Group D nibble extraction returns false on out-of-range/non-hex chars.
 - `Device` (`roborockCommunication/models/device.ts`) has no `.rooms` — room data lives in `Device.mapInfos: MapEntry[]` (each entry has `.rooms: MapRoomDto[]`).
 - `npm run format` covers `**/*.md` — it can reformat markdown emphasis in unrelated dirty files. Diff-check after formatting and revert out-of-scope changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.8-rc01] - 2026-07-20
+
+### Fixed
+
+- **Error-clear transitions not reported to Matter controller** — `V1StatusListener` and `handleHomeDataMessage` only ran the error-handling path when the error code was non-zero, so a device clearing an error never reached the existing clear-to-`NoError` reset logic. Both gates now fire whenever the error field is defined, matching the already-correct `B01StatusListener` pattern.
+
+<a href="https://www.buymeacoffee.com/rinnvspktr" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+---
+
 ## [1.1.7] - 2026-07-17
 
 ### Changed

--- a/matterbridge-roborock-vacuum-plugin.config.json
+++ b/matterbridge-roborock-vacuum-plugin.config.json
@@ -1,7 +1,7 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
 	"type": "DynamicPlatform",
-	"version": "1.1.7",
+	"version": "1.1.8-rc01",
 	"authentication": {
 		"username": "",
 		"region": "US",

--- a/matterbridge-roborock-vacuum-plugin.schema.json
+++ b/matterbridge-roborock-vacuum-plugin.schema.json
@@ -1,6 +1,6 @@
 {
 	"title": "Matterbridge Roborock Vacuum Plugin",
-	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.7 by https://github.com/RinDevJunior",
+	"description": "matterbridge-roborock-vacuum-plugin v. 1.1.8-rc01 by https://github.com/RinDevJunior",
 	"type": "object",
 	"properties": {
 		"name": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "matterbridge-roborock-vacuum-plugin",
-	"version": "1.1.7",
+	"version": "1.1.8-rc01",
 	"description": "Matterbridge Roborock Vacuum Plugin",
 	"author": "https://github.com/RinDevJunior",
 	"license": "MIT",
@@ -40,8 +40,8 @@
 		"build:production": "tsc --project tsconfig.production.json",
 		"start": "tsc && matterbridge -childbridge",
 		"cli": "node dist/cli.js",
-		"build:package": "cd .. && tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.7.tgz matterbridge-roborock-vacuum-plugin",
-		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.7.tgz matterbridge-roborock-vacuum-plugin",
+		"build:package": "cd .. && tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.8.tgz matterbridge-roborock-vacuum-plugin",
+		"build:compress": "tar --exclude-from='matterbridge-roborock-vacuum-plugin/.tarignore' -czvf matterbridge-roborock-vacuum-plugin-1.1.8.tgz matterbridge-roborock-vacuum-plugin",
 		"dup-check": "npx jscpd",
 		"build": "tsc",
 		"type-check": "tsc --noEmit",

--- a/src/roborockCommunication/routing/listeners/implementation/v1StatusListener.ts
+++ b/src/roborockCommunication/routing/listeners/implementation/v1StatusListener.ts
@@ -1,7 +1,6 @@
 import { AnsiLogger, debugStringify } from 'matterbridge/logger';
 
 import { CleanModeSetting } from '../../../../behaviors/roborock.vacuum/core/CleanModeSetting.js';
-import { DockStationStatus } from '../../../../model/DockStationStatus.js';
 import {
 	BatteryMessage,
 	DeviceStatus,
@@ -99,15 +98,7 @@ export class V1StatusListener implements AbstractMessageListener {
 
 		const batteryMessage = new BatteryMessage(message.duid, battery, chargeStatus, state);
 
-		const dockStationStatus =
-			dockStationStatusCode !== undefined ? DockStationStatus.parseDockStationStatus(dockStationStatusCode) : undefined;
-		const hasDockStationError = dockStationStatus?.hasError() ?? false;
-
-		if (
-			(vacuumErrorCode !== undefined && vacuumErrorCode !== 0) ||
-			(dockErrorCode !== undefined && dockErrorCode !== 0) ||
-			hasDockStationError
-		) {
+		if (vacuumErrorCode !== undefined || dockErrorCode !== undefined || dockStationStatusCode !== undefined) {
 			await this.handler.onError(new VacuumError(message.duid, vacuumErrorCode, dockErrorCode, dockStationStatusCode));
 		}
 

--- a/src/runtimes/handleHomeDataMessage.ts
+++ b/src/runtimes/handleHomeDataMessage.ts
@@ -48,7 +48,7 @@ export async function updateFromHomeData(homeData: Home, platform: RoborockMatte
 		const waterBoxMode = getVacuumProperty(device, 'water_box_mode');
 		const chargeStatus = getVacuumProperty(device, 'charge_status');
 
-		if (errorCode && errorCode !== 0) {
+		if (errorCode !== undefined) {
 			await platform.platformRunner.updateRobotWithPayload({
 				type: NotifyMessageTypes.ErrorOccurred,
 				data: {

--- a/src/tests/roborockCommunication/broadcast/listener/implementation/v1StatusListener.test.ts
+++ b/src/tests/roborockCommunication/broadcast/listener/implementation/v1StatusListener.test.ts
@@ -59,7 +59,7 @@ describe('V1StatusListener', () => {
 		await listener.onMessage(message);
 		expect(handler.onBatteryUpdate).toHaveBeenCalledWith(expect.objectContaining({ percentage: 100 }));
 		expect(handler.onStatusChanged).toHaveBeenCalledWith(expect.anything());
-		expect(handler.onError).not.toHaveBeenCalled();
+		expect(handler.onError).toHaveBeenCalledWith(expect.objectContaining({ vacuumErrorCode: 0, dockErrorCode: 0 }));
 	});
 
 	it('should handle rpc_response with error_code', async () => {
@@ -134,5 +134,44 @@ describe('V1StatusListener', () => {
 		expect(handler.onStatusChanged).not.toHaveBeenCalled();
 		expect(handler.onError).not.toHaveBeenCalled();
 		expect(logger.debug).toHaveBeenCalledWith("[V1StatusListener]: Ignoring simple 'ok' response");
+	});
+
+	it('should not call onError when error_code and dock_error_status fields are absent entirely', async () => {
+		message.isForProtocols.mockReturnValue(true);
+		message.get.mockReturnValue({
+			id: 15472,
+			result: [{ battery: 85, state: 8, dock_type: 1 }], // No error_code or dock_error_status
+		});
+		await listener.onMessage(message);
+		expect(handler.onBatteryUpdate).toHaveBeenCalledWith(expect.objectContaining({ percentage: 85 }));
+		expect(handler.onStatusChanged).toHaveBeenCalledWith(expect.anything());
+		expect(handler.onError).not.toHaveBeenCalled();
+	});
+
+	it('should call onError twice when error transitions from non-zero to zero in sequential messages', async () => {
+		message.isForProtocols.mockReturnValue(true);
+
+		// First message with non-zero vacuum error
+		message.get.mockReturnValue({
+			id: 15472,
+			result: [{ battery: 100, state: 8, error_code: 5, dock_error_status: 0, dock_type: 1 }],
+		});
+		await listener.onMessage(message);
+		expect(handler.onError).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(handler.onError).mock.calls[0]?.[0]).toMatchObject({ vacuumErrorCode: 5 });
+
+		vi.clearAllMocks();
+
+		// Second message with error cleared to zero
+		message.get.mockReturnValue({
+			id: 15473,
+			result: [{ battery: 100, state: 8, error_code: 0, dock_error_status: 0, dock_type: 1 }],
+		});
+		await listener.onMessage(message);
+		expect(handler.onError).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(handler.onError).mock.calls[0]?.[0]).toMatchObject({
+			vacuumErrorCode: 0,
+			dockErrorCode: 0,
+		});
 	});
 });

--- a/src/tests/roborockCommunication/routing/listeners/implementation/v1StatusListener.test.ts
+++ b/src/tests/roborockCommunication/routing/listeners/implementation/v1StatusListener.test.ts
@@ -211,7 +211,12 @@ describe('V1StatusListener', () => {
 			expect(handler.onStatusChanged).toHaveBeenCalled();
 			expect(handler.onCleanModeUpdate).toHaveBeenCalled();
 			expect(handler.onServiceAreaUpdate).toHaveBeenCalled();
-			expect(handler.onError).not.toHaveBeenCalled();
+			expect(handler.onError).toHaveBeenCalledWith(
+				expect.objectContaining({
+					vacuumErrorCode: VacuumErrorCode.None,
+					dockErrorCode: DockErrorCode.None,
+				}),
+			);
 		});
 
 		it('should call onError when vacuum error code is non-zero', async () => {
@@ -320,6 +325,57 @@ describe('V1StatusListener', () => {
 			const serviceAreaCall = vi.mocked(handler.onServiceAreaUpdate).mock.calls[0]?.[0];
 			expect(serviceAreaCall?.cleaningProcess).toEqual({ clean_area: 50, clean_time: 30 });
 			expect(serviceAreaCall?.cleaningProcess).not.toHaveProperty('clean_percent');
+		});
+
+		it('should not call onError when error_code, dock_error_status, and dss fields are absent entirely', async () => {
+			listener.registerHandler(handler);
+			const bodyWithoutErrorFields = {
+				state: OperationStatusCode.Idle,
+				battery: 80,
+				charge_status: 8,
+				in_cleaning: 0,
+				in_returning: 0,
+				in_fresh_state: 0,
+				is_locating: 0,
+				is_exploring: 0,
+				in_warmup: 0,
+				fan_power: 102,
+				water_box_mode: 203,
+				distance_off: 25,
+				mop_mode: 300,
+				seq_type: 0,
+				// Intentionally omitting: error_code, dock_error_status, dss
+			};
+			const message = makeRpcResponseMessage(duid, bodyWithoutErrorFields);
+			await listener.onMessage(message);
+			expect(handler.onError).not.toHaveBeenCalled();
+			expect(handler.onBatteryUpdate).toHaveBeenCalled();
+		});
+
+		it('should call onError twice when error transitions from non-zero to zero in sequential messages', async () => {
+			listener.registerHandler(handler);
+
+			// First message with non-zero vacuum error
+			const messageWithError = makeRpcResponseMessage(duid, {
+				...baseResultBody,
+				error_code: VacuumErrorCode.LidarBlocked,
+			});
+			await listener.onMessage(messageWithError);
+			expect(handler.onError).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(handler.onError).mock.calls[0]?.[0]).toMatchObject({
+				vacuumErrorCode: VacuumErrorCode.LidarBlocked,
+			});
+
+			vi.clearAllMocks();
+
+			// Second message with error cleared to zero
+			const messageCleared = makeRpcResponseMessage(duid, baseResultBody);
+			await listener.onMessage(messageCleared);
+			expect(handler.onError).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(handler.onError).mock.calls[0]?.[0]).toMatchObject({
+				vacuumErrorCode: VacuumErrorCode.None,
+				dockErrorCode: DockErrorCode.None,
+			});
 		});
 	});
 });

--- a/src/tests/runtimes/handleHomeDataMessage.test.ts
+++ b/src/tests/runtimes/handleHomeDataMessage.test.ts
@@ -305,4 +305,49 @@ describe('updateFromHomeData', () => {
 		await updateFromHomeData(homeDataMismatch, platform);
 		expect(platformRunner.updateRobotWithPayload).toHaveBeenCalled();
 	});
+
+	it('should dispatch ErrorOccurred when error_code is 0 (cleared error)', async () => {
+		const homeDataWithClearedError = asPartial<Home>({
+			...homeData,
+			devices: [{ ...homeData.devices[0], deviceStatus: asPartial({ state: 8, battery: 100, error_code: 0 }) }],
+		});
+		platform.registry.robotsMap.clear();
+		platform.registry.robotsMap.set('test-duid', robot);
+
+		await updateFromHomeData(homeDataWithClearedError, platform);
+		expect(platformRunner.updateRobotWithPayload).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ErrorOccurred',
+				data: expect.objectContaining({
+					vacuumErrorCode: 0,
+					dockErrorCode: 0,
+				}),
+			}),
+		);
+	});
+
+	it('should not dispatch ErrorOccurred when error_code field is absent from device status', async () => {
+		const homeDataWithoutErrorCode = asPartial<Home>({
+			...homeData,
+			devices: [{ ...homeData.devices[0], deviceStatus: asPartial({ state: 8, battery: 100 }) }],
+		});
+		platform.registry.robotsMap.clear();
+		platform.registry.robotsMap.set('test-duid', robot);
+
+		vi.clearAllMocks();
+		await updateFromHomeData(homeDataWithoutErrorCode, platform);
+
+		// Verify ErrorOccurred was NOT called for missing error_code
+		expect(platformRunner.updateRobotWithPayload).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ErrorOccurred',
+			}),
+		);
+		// But DeviceStatusSimple should still be called
+		expect(platformRunner.updateRobotWithPayload).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'DeviceStatusSimple',
+			}),
+		);
+	});
 });

--- a/workspace/claude_history.md
+++ b/workspace/claude_history.md
@@ -1,5 +1,19 @@
 # Claude History
 
+## 2026-07-18 — Fix error-clear transitions not reported to Matter
+
+**Task:** Fix bug where vacuum/dock error-clear transitions were never reported to the Matter controller. Root cause: error-handling gates in v1StatusListener.ts and handleHomeDataMessage.ts only fired when error code was non-zero, preventing the error-clear path from ever reaching the correct reset logic in handleErrorOccurred.
+
+**Changes:**
+
+- `src/roborockCommunication/routing/listeners/implementation/v1StatusListener.ts` — widened error gate to fire whenever error field is defined (not just non-zero)
+- `src/runtimes/handleHomeDataMessage.ts` — widened error gate to match v1StatusListener pattern
+- `src/tests/roborockCommunication/routing/listeners/implementation/v1StatusListener.test.ts` — updated stale assertions, added field-absent and error-clear-transition coverage
+- `src/tests/roborockCommunication/broadcast/listener/implementation/v1StatusListener.test.ts` — updated stale assertions and added transition coverage
+- `src/tests/runtimes/handleHomeDataMessage.test.ts` — updated stale assertions and added field-absent/clear-transition coverage
+
+**Outcome:** Pass (reviewer approved; all verification gates passed: format:ci, lint:fix:ci, type-check:ci, test:ci).
+
 ## 2026-07-14 — Reset ServiceArea.progress on clean start (third trigger)
 
 **Task:** Add third trigger for resetting `ServiceArea.progress` per-room state when vacuum starts new clean; detect genuine Docked/Stopped/Error → actively-cleaning operationalState transitions using `lastActivelyCleaningState` flag to avoid false positives on mid-clean detours.


### PR DESCRIPTION
## Summary
- When a vacuum/dock error is reported, the plugin correctly forwarded it to the Matter controller — but when the error cleared on the device, the plugin never reported the clear, leaving the controller stuck showing a stale error.
- Root cause: `v1StatusListener.ts` and `handleHomeDataMessage.ts` only invoked the error-handling path when the error code was non-zero, so a clear-to-0 transition never reached the existing (correct) clear-to-`NoError` reset logic in `handleErrorOccurred`.
- Fix: widen both gates to fire whenever the error field is *defined* (including 0), matching the pattern already used correctly in `b01StatusListener.ts`.

## Files changed
- `src/roborockCommunication/routing/listeners/implementation/v1StatusListener.ts`
- `src/runtimes/handleHomeDataMessage.ts`
- `src/tests/roborockCommunication/routing/listeners/implementation/v1StatusListener.test.ts`
- `src/tests/roborockCommunication/broadcast/listener/implementation/v1StatusListener.test.ts`
- `src/tests/runtimes/handleHomeDataMessage.test.ts`

## Test plan
- [x] `format:ci` pass
- [x] `lint:fix:ci` pass
- [x] `type-check:ci` pass
- [x] `test:ci` pass (existing stale assertions fixed, new coverage added for cleared-error and field-absent cases)


---
_Generated by [Claude Code](https://claude.ai/code/session_01B1SqAVk7XvnWuBkmR1kxNc)_