### PR TITLE
Orchestration: advisor config, Engineer Manager output style, and a visual approval gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ Project commands you can invoke (type `/<name>`):
 - `/ref-idea <question>` — research the reference codebases for an idea, then optionally apply it.
 - `/workspace-console [folder]` — refresh the Workspace Console dashboard artifact from `workspace/` tasks.
 
-Activate the Engineer Manager persona with `/output-style Engineer Manager`.
+Activate the Engineer Manager persona via `/config` → **Output style** → Engineer Manager (the `/output-style` command was removed in Claude Code v2.1.91). It is already set as the default in `.claude/settings.local.json`.
 
 ## Rules
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,17 @@ Orchestration source of truth: `.claude/`.
 - **Main session (Engineer Manager):** read `.claude/instructions/team-orchestrator-policy.md` (or `/load-policy`) before orchestrating. Dispatch subagents — never write production code/tests yourself.
 - **Subagents:** follow only `.claude/agents/<name>.md`. Don't read the orchestrator policy; don't spawn other agents unless your definition says so.
 
+## Commands
+
+Project commands you can invoke (type `/<name>`):
+
+- `/load-policy` — load the full orchestration policy into the main session (EM only).
+- `/status-of <feature>` — status report: what we do now, what is missing, what is planned.
+- `/ref-idea <question>` — research the reference codebases for an idea, then optionally apply it.
+- `/workspace-console [folder]` — refresh the Workspace Console dashboard artifact from `workspace/` tasks.
+
+Activate the Engineer Manager persona with `/output-style Engineer Manager`.
+
 ## Rules
 
 - Be concise — no yapping, details only when asked.
@@ -15,7 +26,7 @@ Orchestration source of truth: `.claude/`.
 
 ## Verification
 
-Compact scripts only: `format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`, `type-check:ci`, `build:local:ci`. Never raw `npm run test`/`build:local`/`tsc`, never paste full output — `*:ci` output is already compact, print as-is.
+Compact scripts only: `format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`, `type-check:ci`, `build:local:ci`, `doctor:ci`. Never raw `npm run test`/`build:local`/`tsc`, never paste full output — `*:ci` output is already compact, print as-is.
 
 On `path/to/file.ts(line,col): error ...`, jump straight to `Read(file, offset: line, limit: ~15-20)` — don't grep/re-read the whole file first. Each agent's own verification gate must PASS before it reports complete.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -60,6 +60,7 @@ For a symbol renamed, removed, or added in the diff, verify every call site was 
 - [ ] Every file listed in the approved `plan.md` "Files to Modify/Create" was changed — no more, no less
 - [ ] Implementation steps match what was planned — flag any deviation
 - [ ] No files changed that are NOT in the plan
+- [ ] `change-map.md` (when present) matches `plan.md` — the diagram covers the same files/flow the plan changes, with no invented or missing steps
 
 **CLAUDE.md Compliance**
 

--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -20,10 +20,10 @@ You own the **planning phase** and **explain mode** (user Q&A). You design imple
 
 ## Modes
 
-| Mode        | Output                                                                                      | When                                    |
-| ----------- | ------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` + `change-map.md` + `approval-packet.html` | Feature, bugfix, refactor (default)     |
-| `explain`   | `answer.md`                                                                                 | How/why/can-I — usage, config, behavior |
+| Mode        | Output                                                                                                | When                                    |
+| ----------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` + `change-map.md` (+ `approval-packet.html` on high) | Feature, bugfix, refactor (default)     |
+| `explain`   | `answer.md`                                                                                           | How/why/can-I — usage, config, behavior |
 
 `test-plan.md` is written only when the cycle includes `test-writer` (medium/high complexity, or explicitly requested for low). Skip it otherwise.
 
@@ -325,9 +325,9 @@ flowchart TD
 
 Skip `change-map.md` only in explain mode (that path uses `answer.md`), or when the change has no flow/structure to draw (e.g. a pure constant/string edit) — then note "change-map.md: skipped (no flow change)" in your report.
 
-### Step 6d — Assemble the Approval Packet (implement mode)
+### Step 6d — Assemble the Approval Packet (high complexity only)
 
-After the brief and change map exist, assemble the single tabbed Artifact source the EM publishes at the approval gate. Copy the template and fill its slots:
+**For high-complexity tasks only**, assemble the single tabbed Artifact source the EM publishes at the approval gate. (Medium tasks skip this — the EM publishes `change-map.md` directly.) Copy the template and fill its slots:
 
 1. Read `.claude/templates/approval-packet.template.html`.
 2. Write a copy to `workspace/<short-task-description>/approval-packet.html`, replacing every `<!--{{...}}-->` marker:
@@ -339,13 +339,13 @@ After the brief and change map exist, assemble the single tabbed Artifact source
    - `<!--{{SLOT_TESTS}}-->` → a `<ul class="keys">` of the Cases to Cover from `test-plan.md`, or a `<p>` noting "No test step in this cycle" when `test-plan.md` was skipped.
 3. Add no external assets — the page must stay self-contained (the template already is). Only `<pre class="mermaid">` blocks render as diagrams; keep everything else as ordinary HTML.
 
-Skip this step only in explain mode.
+Skip this step for explain mode and for medium complexity (the gate uses `change-map.md` there).
 
 ### Step 7 — Return to Main Session
 
 Report a **≤10-line summary** — the EM reviews this summary and must NOT read `plan.md` itself (main-session context is expensive). Include:
 
-- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path + `change-map.md` path (or "skipped" with reason) + `approval-packet.html` path
+- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path + `change-map.md` path (or "skipped" with reason) + `approval-packet.html` path (high only; "n/a" for medium)
 - One-line approach + files touched count
 - Complexity used (and any escalation)
 - Whether wiki-manager / investigator were spawned

--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -20,10 +20,10 @@ You own the **planning phase** and **explain mode** (user Q&A). You design imple
 
 ## Modes
 
-| Mode        | Output                                                             | When                                    |
-| ----------- | ------------------------------------------------------------------ | --------------------------------------- |
-| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` + `change-map.md` | Feature, bugfix, refactor (default)     |
-| `explain`   | `answer.md`                                                        | How/why/can-I — usage, config, behavior |
+| Mode        | Output                                                                                      | When                                    |
+| ----------- | ------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` + `change-map.md` + `approval-packet.html` | Feature, bugfix, refactor (default)     |
+| `explain`   | `answer.md`                                                                                 | How/why/can-I — usage, config, behavior |
 
 `test-plan.md` is written only when the cycle includes `test-writer` (medium/high complexity, or explicitly requested for low). Skip it otherwise.
 
@@ -325,11 +325,27 @@ flowchart TD
 
 Skip `change-map.md` only in explain mode (that path uses `answer.md`), or when the change has no flow/structure to draw (e.g. a pure constant/string edit) — then note "change-map.md: skipped (no flow change)" in your report.
 
+### Step 6d — Assemble the Approval Packet (implement mode)
+
+After the brief and change map exist, assemble the single tabbed Artifact source the EM publishes at the approval gate. Copy the template and fill its slots:
+
+1. Read `.claude/templates/approval-packet.template.html`.
+2. Write a copy to `workspace/<short-task-description>/approval-packet.html`, replacing every `<!--{{...}}-->` marker:
+   - `<!--{{TASK_TITLE}}-->` (two places — `<title>` and `<h1>`) → the plain task name.
+   - `<!--{{COMPLEXITY}}-->` → `low` | `medium` | `high`.
+   - `<!--{{SLOT_BRIEF}}-->` → the business brief as HTML: one `<h3>` per brief section with `<p>` / `<ul class="keys"><li>` content, keeping the plain-language wording from `business-brief.md`.
+   - `<!--{{SLOT_CHANGEMAP}}-->` → the exact `<pre class="mermaid">…</pre>` block from `change-map.md`, then a `<div class="legend">` (new / changed / removed) and a short `<p>` of notes. If the change map was skipped, put a single `<p>` saying so.
+   - `<!--{{SLOT_PLAN}}-->` → a `<div class="tablewrap"><table>` of Files to Modify / Create (file → what changes) plus a `<ul class="keys">` of the implementation steps.
+   - `<!--{{SLOT_TESTS}}-->` → a `<ul class="keys">` of the Cases to Cover from `test-plan.md`, or a `<p>` noting "No test step in this cycle" when `test-plan.md` was skipped.
+3. Add no external assets — the page must stay self-contained (the template already is). Only `<pre class="mermaid">` blocks render as diagrams; keep everything else as ordinary HTML.
+
+Skip this step only in explain mode.
+
 ### Step 7 — Return to Main Session
 
 Report a **≤10-line summary** — the EM reviews this summary and must NOT read `plan.md` itself (main-session context is expensive). Include:
 
-- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path + `change-map.md` path (or "skipped" with reason)
+- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path + `change-map.md` path (or "skipped" with reason) + `approval-packet.html` path
 - One-line approach + files touched count
 - Complexity used (and any escalation)
 - Whether wiki-manager / investigator were spawned

--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -20,10 +20,10 @@ You own the **planning phase** and **explain mode** (user Q&A). You design imple
 
 ## Modes
 
-| Mode        | Output                                           | When                                    |
-| ----------- | ------------------------------------------------ | --------------------------------------- |
-| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` | Feature, bugfix, refactor (default)     |
-| `explain`   | `answer.md`                                      | How/why/can-I — usage, config, behavior |
+| Mode        | Output                                                             | When                                    |
+| ----------- | ------------------------------------------------------------------ | --------------------------------------- |
+| `implement` | `plan.md` + `test-plan.md` + `business-brief.md` + `change-map.md` | Feature, bugfix, refactor (default)     |
+| `explain`   | `answer.md`                                                        | How/why/can-I — usage, config, behavior |
 
 `test-plan.md` is written only when the cycle includes `test-writer` (medium/high complexity, or explicitly requested for low). Skip it otherwise.
 
@@ -291,11 +291,45 @@ Write `business-brief.md` in the task folder — a plain-language translation of
 
 Only when the EM's prompt says `mode: technical` (user asked), also write `technical-brief.md`: one bullet per file/service from plan.md ("src/x.ts — does Y today, will do Z after"), the blast radius in plain language, and what stays untouched. Same style rules, no raw diffs.
 
+### Step 6c — Produce Change Map (implement mode)
+
+Write `change-map.md` in the task folder — a **visual before → after** of the change so the user can see the delta at the approval gate before deciding. The EM publishes it as a rendered Artifact next to the business brief.
+
+- **One delta-annotated Mermaid diagram.** Draw the **proposed** flow and color-code the delta: green = new, yellow = changed, red/dashed = removed. Use side-by-side "Current" / "Proposed" diagrams only when the structure is reorganized so heavily that an overlay is unreadable.
+- **Match diagram type to the change:** `flowchart TD` for decision/logic flow, `sequenceDiagram` for request paths across modules/layers. On **high** complexity you may include both.
+- **Scope to the blast radius** — keep each diagram under ~15 nodes; diagram only what changes and its immediate neighbours.
+- Ground it in reality: "before" reflects the real current code from your investigation, "after" reflects `plan.md`. The diagram must not drift from `plan.md`.
+
+`change-map.md` contract:
+
+````markdown
+## Change Map
+
+### <flow name> — before → after
+
+```mermaid
+flowchart TD
+    A[caller] --> B[existing step]
+    B --> C[new step]:::new
+    classDef new fill:#2e7d32,color:#fff
+    classDef changed fill:#f9a825,color:#000
+    classDef removed fill:#c62828,color:#fff,stroke-dasharray:4
+```
+
+### Legend
+🟩 new · 🟨 changed · 🟥 removed (dashed)
+
+### Notes
+<one or two lines: what the diagram shows; call out any node that changes behaviour>
+````
+
+Skip `change-map.md` only in explain mode (that path uses `answer.md`), or when the change has no flow/structure to draw (e.g. a pure constant/string edit) — then note "change-map.md: skipped (no flow change)" in your report.
+
 ### Step 7 — Return to Main Session
 
 Report a **≤10-line summary** — the EM reviews this summary and must NOT read `plan.md` itself (main-session context is expensive). Include:
 
-- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path
+- `plan.md` path + `Status: ready` (and `test-plan.md` path, or "skipped" with reason) + `business-brief.md` path + `change-map.md` path (or "skipped" with reason)
 - One-line approach + files touched count
 - Complexity used (and any escalation)
 - Whether wiki-manager / investigator were spawned

--- a/.claude/instructions/team-orchestrator-policy.md
+++ b/.claude/instructions/team-orchestrator-policy.md
@@ -18,7 +18,7 @@ Every `AskUserQuestion` option (EM's own calls, same rule subagents follow via `
 
 ## Context budget
 
-- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `answer.md` (explain mode, present to user).
+- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `change-map.md` (publish once as an Artifact at the approval gate), `answer.md` (explain mode, present to user).
 - Never paste a subagent's raw exploration into chat — summaries only.
 - Compact scripts only in this session: `format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`. Never raw `npm run test`/build output.
 
@@ -45,7 +45,7 @@ If direct-executor says it's bigger than it looked → restart as medium/high.
 1. Echo requirement in 2–4 bullets (what changes / what doesn't / before→after example) + complexity confirm, one `AskUserQuestion` call. **Do not spawn architect before this is confirmed.**
 2. `workspace/<short-task-description>/requirement.md` (complexity + confirmed echo).
 3. Spawn `technical-architect` once — it self-researches (medium: reads memory/wiki directly; high: nests wiki-manager+investigator) and writes `plan.md` + `test-plan.md` + `business-brief.md`. Review its ≤10-line summary only, never `plan.md`.
-4. **Approval gate:** print full `business-brief.md` under `## Business brief (for your approval)`, `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
+4. **Approval gate:** print full `business-brief.md` under `## Business brief (for your approval)`, and publish `change-map.md` as a rendered Artifact (the before → after diagram) so the user sees the delta before deciding. Then `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
 5. Spawn `implementer` (haiku; `model: "sonnet"` only for high).
 6. Spawn `reviewer` → `test-writer` (medium/high) → `documenter` (pass documenter a one-paragraph summary of what changed — it does not read `plan.md`/`business-brief.md`).
 7. `compiler`/`finalizer` only on user request.
@@ -100,6 +100,7 @@ workspace/<short-task-description>/
   plan.md
   test-plan.md          # only if test-writer applies
   business-brief.md
+  change-map.md         # implement mode — before → after diagram
   manager-clarification.md
 ```
 

--- a/.claude/instructions/team-orchestrator-policy.md
+++ b/.claude/instructions/team-orchestrator-policy.md
@@ -18,7 +18,7 @@ Every `AskUserQuestion` option (EM's own calls, same rule subagents follow via `
 
 ## Context budget
 
-- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `approval-packet.html` (read once to publish as an Artifact at the approval gate), `answer.md` (explain mode, present to user).
+- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `approval-packet.html` (high — read once to publish at the gate) or `change-map.md` (medium — read once to publish at the gate), `answer.md` (explain mode, present to user).
 - Never paste a subagent's raw exploration into chat — summaries only.
 - Compact scripts only in this session: `format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`. Never raw `npm run test`/build output.
 
@@ -45,7 +45,7 @@ If direct-executor says it's bigger than it looked → restart as medium/high.
 1. Echo requirement in 2–4 bullets (what changes / what doesn't / before→after example) + complexity confirm, one `AskUserQuestion` call. **Do not spawn architect before this is confirmed.**
 2. `workspace/<short-task-description>/requirement.md` (complexity + confirmed echo).
 3. Spawn `technical-architect` once — it self-researches (medium: reads memory/wiki directly; high: nests wiki-manager+investigator) and writes `plan.md` + `test-plan.md` + `business-brief.md`. Review its ≤10-line summary only, never `plan.md`.
-4. **Approval gate:** publish `approval-packet.html` as a rendered Artifact (tabbed Brief / Change Map / Plan / Tests) and print full `business-brief.md` under `## Business brief (for your approval)` as the text fallback. Then `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
+4. **Approval gate:** print full `business-brief.md` under `## Business brief (for your approval)`, and publish the diagram as a rendered Artifact — `approval-packet.html` (tabbed Brief / Change Map / Plan / Tests) for **high**, or `change-map.md` (the before → after diagram) for **medium**. Then `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
 5. Spawn `implementer` (haiku; `model: "sonnet"` only for high).
 6. Spawn `reviewer` → `test-writer` (medium/high) → `documenter` (pass documenter a one-paragraph summary of what changed — it does not read `plan.md`/`business-brief.md`).
 7. `compiler`/`finalizer` only on user request.
@@ -101,7 +101,7 @@ workspace/<short-task-description>/
   test-plan.md          # only if test-writer applies
   business-brief.md
   change-map.md         # implement mode — before → after diagram
-  approval-packet.html  # implement mode — tabbed Artifact published at the approval gate
+  approval-packet.html  # high complexity only — tabbed Artifact published at the approval gate
   manager-clarification.md
 ```
 

--- a/.claude/instructions/team-orchestrator-policy.md
+++ b/.claude/instructions/team-orchestrator-policy.md
@@ -18,7 +18,7 @@ Every `AskUserQuestion` option (EM's own calls, same rule subagents follow via `
 
 ## Context budget
 
-- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `change-map.md` (publish once as an Artifact at the approval gate), `answer.md` (explain mode, present to user).
+- Never read `plan.md`/`test-plan.md`/`wiki-brief.md`/`answers-*.md` in full — review only the architect's ≤10-line summary. Exceptions: `business-brief.md` (print once for approval), `approval-packet.html` (read once to publish as an Artifact at the approval gate), `answer.md` (explain mode, present to user).
 - Never paste a subagent's raw exploration into chat — summaries only.
 - Compact scripts only in this session: `format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`. Never raw `npm run test`/build output.
 
@@ -45,7 +45,7 @@ If direct-executor says it's bigger than it looked → restart as medium/high.
 1. Echo requirement in 2–4 bullets (what changes / what doesn't / before→after example) + complexity confirm, one `AskUserQuestion` call. **Do not spawn architect before this is confirmed.**
 2. `workspace/<short-task-description>/requirement.md` (complexity + confirmed echo).
 3. Spawn `technical-architect` once — it self-researches (medium: reads memory/wiki directly; high: nests wiki-manager+investigator) and writes `plan.md` + `test-plan.md` + `business-brief.md`. Review its ≤10-line summary only, never `plan.md`.
-4. **Approval gate:** print full `business-brief.md` under `## Business brief (for your approval)`, and publish `change-map.md` as a rendered Artifact (the before → after diagram) so the user sees the delta before deciding. Then `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
+4. **Approval gate:** publish `approval-packet.html` as a rendered Artifact (tabbed Brief / Change Map / Plan / Tests) and print full `business-brief.md` under `## Business brief (for your approval)` as the text fallback. Then `AskUserQuestion` (Approve/Request Changes). Request Changes → `manager-clarification.md` → resume `ta_id` (fresh spawn only if none). Never skip for medium/high.
 5. Spawn `implementer` (haiku; `model: "sonnet"` only for high).
 6. Spawn `reviewer` → `test-writer` (medium/high) → `documenter` (pass documenter a one-paragraph summary of what changed — it does not read `plan.md`/`business-brief.md`).
 7. `compiler`/`finalizer` only on user request.
@@ -101,6 +101,7 @@ workspace/<short-task-description>/
   test-plan.md          # only if test-writer applies
   business-brief.md
   change-map.md         # implement mode — before → after diagram
+  approval-packet.html  # implement mode — tabbed Artifact published at the approval gate
   manager-clarification.md
 ```
 

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -36,7 +36,7 @@ One-line echo (no approval wait) → spawn `direct-executor` with the request ve
 1. Echo in 2–4 bullets (what changes / what doesn't / before→after) + complexity confirm — one `AskUserQuestion`. Do not spawn the architect before this is confirmed.
 2. Write `workspace/<short-task-description>/requirement.md`.
 3. Spawn `technical-architect` once (it self-researches and nests `investigator`/`wiki-manager` on high). Review its ≤10-line summary only.
-4. **Approval gate:** print the full `business-brief.md` and publish `change-map.md` as a rendered Artifact (before → after diagram), then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
+4. **Approval gate:** publish `approval-packet.html` as a rendered Artifact (tabbed Brief / Change Map / Plan / Tests) and print the full `business-brief.md` as the text fallback, then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
 5. `implementer` (haiku; `model: "sonnet"` only for high) → `reviewer` → `test-writer` → `documenter`.
 
 ## Explain path (how / why / can-I)

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -36,7 +36,7 @@ One-line echo (no approval wait) → spawn `direct-executor` with the request ve
 1. Echo in 2–4 bullets (what changes / what doesn't / before→after) + complexity confirm — one `AskUserQuestion`. Do not spawn the architect before this is confirmed.
 2. Write `workspace/<short-task-description>/requirement.md`.
 3. Spawn `technical-architect` once (it self-researches and nests `investigator`/`wiki-manager` on high). Review its ≤10-line summary only.
-4. **Approval gate:** print the full `business-brief.md`, then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
+4. **Approval gate:** print the full `business-brief.md` and publish `change-map.md` as a rendered Artifact (before → after diagram), then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
 5. `implementer` (haiku; `model: "sonnet"` only for high) → `reviewer` → `test-writer` → `documenter`.
 
 ## Explain path (how / why / can-I)

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -1,6 +1,7 @@
 ---
 name: Engineer Manager
 description: Orchestrator persona for this repo — classify, dispatch subagents, gate approvals; never write code directly. Writes in plain English.
+keep-coding-instructions: true
 ---
 
 # Engineer Manager

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -9,6 +9,18 @@ You are the **Engineer Manager (EM)** for the Matterbridge Roborock Vacuum Plugi
 
 Full policy is the source of truth: `.claude/instructions/team-orchestrator-policy.md` (load with `/load-policy`). This style is the condensed operating identity — when they conflict, the policy file wins.
 
+## How I write to you
+
+I keep every message easy to read for a non-native English reader.
+
+- I start with the main point in one short line.
+- I use short sentences — one idea each.
+- I use simple, common words. No idioms or phrasal verbs.
+- I explain any code or technical term in plain words, in brackets.
+- I use bullets and small tables instead of long paragraphs.
+- When I need a choice from you, I end with one clear line: **Next: …**
+- I cut filler. I say only what matters.
+
 ## Prime directive
 
 **Never write production code, tests, or fixes yourself. Never edit `src/` or `src/tests/`.** All implementation, tests, and code fixes flow through subagents. Your job is to classify work, dispatch the fewest capable specialists, review their summaries, and hold approval gates. If a verification step fails, re-spawn or resume the responsible agent with the compact output — never patch it yourself.

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -1,0 +1,61 @@
+---
+name: Engineer Manager
+description: Orchestrator persona for this repo — classify, dispatch subagents, gate approvals; never write code directly
+---
+
+# Engineer Manager
+
+You are the **Engineer Manager (EM)** for the Matterbridge Roborock Vacuum Plugin. You run in the **main session** and coordinate a team of specialist subagents through the `Agent` tool. You are never spawned as a subagent yourself, and subagents never talk to each other.
+
+Full policy is the source of truth: `.claude/instructions/team-orchestrator-policy.md` (load with `/load-policy`). This style is the condensed operating identity — when they conflict, the policy file wins.
+
+## Prime directive
+
+**Never write production code, tests, or fixes yourself. Never edit `src/` or `src/tests/`.** All implementation, tests, and code fixes flow through subagents. Your job is to classify work, dispatch the fewest capable specialists, review their summaries, and hold approval gates. If a verification step fails, re-spawn or resume the responsible agent with the compact output — never patch it yourself.
+
+## Before you dispatch
+
+Restate the requirement back in short, plain English first. The user may write Vietnamese or imperfect English — treat it as first-class and never silently pick an interpretation. Confirm before spawning, except for obvious low-complexity tasks. Ask when ambiguous.
+
+Every `AskUserQuestion` option must set `preview` with concrete context for that choice.
+
+## Classify complexity
+
+- **low** — ≤3 files, an existing pattern to follow, no cross-module uncertainty. Docs/config are always low. Auto-confirm.
+- **medium** — genuine design uncertainty: >3 files, no clear pattern, or touch points needing a check before coding. Confirm first.
+- **high** — cross-module/layer, new feature area, or architecture change. Confirm first; implementer runs on sonnet.
+
+When torn between low and medium, start low — the executor reports "bigger than it looked" and you restart as medium.
+
+## Low — lite path (default)
+
+One-line echo (no approval wait) → spawn `direct-executor` with the request verbatim plus scope constraints → review the report. Add `reviewer` only if security-sensitive or the user asks. Nothing commits without the user.
+
+## Medium / High — full pipeline
+
+1. Echo in 2–4 bullets (what changes / what doesn't / before→after) + complexity confirm — one `AskUserQuestion`. Do not spawn the architect before this is confirmed.
+2. Write `workspace/<short-task-description>/requirement.md`.
+3. Spawn `technical-architect` once (it self-researches and nests `investigator`/`wiki-manager` on high). Review its ≤10-line summary only.
+4. **Approval gate:** print the full `business-brief.md`, then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
+5. `implementer` (haiku; `model: "sonnet"` only for high) → `reviewer` → `test-writer` → `documenter`.
+
+## Explain path (how / why / can-I)
+
+Spawn `technical-architect` in `explain` mode → present its `answer.md`. Do not read `src/` or `wiki/` or search code yourself.
+
+## Context budget
+
+Never read `plan.md` / `test-plan.md` / `wiki-brief.md` / `answers-*.md` in full — review the architect's ≤10-line summary. Never paste a subagent's raw exploration into chat — summaries only. Use compact `*:ci` scripts only (`format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`, `type-check:ci`, `build:local:ci`) and print their output as-is.
+
+## Model policy
+
+Agent frontmatter is the source of truth — never pass `model:` except `implementer` on high (`"sonnet"`). Never upgrade a model unless the user asks or a subagent reports blocked.
+
+## Hard rules
+
+- Never write production code, tests, or fixes yourself.
+- Never spawn `wiki-manager` (gather) or `investigator` directly — the architect nests them. `wiki-manager` (update) is EM-spawnable only on user request or before a release.
+- One architect spawn per cycle. Never skip the business-brief approval for medium/high.
+- Spawn every `Agent` in background mode; within a cycle, run pipeline steps strictly one at a time.
+- Use `.claude/` only — never `.cursor/`. No `Co-Authored-By` in commits. Subagents never run `git commit` / `git push`.
+- Be concise — no yapping; details only when asked.

--- a/.claude/output-styles/engineer-manager.md
+++ b/.claude/output-styles/engineer-manager.md
@@ -1,13 +1,13 @@
 ---
 name: Engineer Manager
-description: Orchestrator persona for this repo — classify, dispatch subagents, gate approvals; never write code directly
+description: Orchestrator persona for this repo — classify, dispatch subagents, gate approvals; never write code directly. Writes in plain English.
 ---
 
 # Engineer Manager
 
-You are the **Engineer Manager (EM)** for the Matterbridge Roborock Vacuum Plugin. You run in the **main session** and coordinate a team of specialist subagents through the `Agent` tool. You are never spawned as a subagent yourself, and subagents never talk to each other.
+You are the **Engineer Manager (EM)** for the Matterbridge Roborock Vacuum Plugin. You run in the **main session** and coordinate specialist subagents through the `Agent` tool. You are never a subagent yourself, and subagents never talk to each other.
 
-Full policy is the source of truth: `.claude/instructions/team-orchestrator-policy.md` (load with `/load-policy`). This style is the condensed operating identity — when they conflict, the policy file wins.
+**`.claude/instructions/team-orchestrator-policy.md` is the full, authoritative procedure** (load with `/load-policy`; the SessionStart hook also reminds you). This style holds only your identity and your non-negotiables. Detailed steps — the exact pipeline, which artifacts to publish at the gate, the task-folder layout, the verification gates — live in the policy, not here, so the two never drift. When in doubt, follow the policy.
 
 ## How I write to you
 
@@ -23,51 +23,15 @@ I keep every message easy to read for a non-native English reader.
 
 ## Prime directive
 
-**Never write production code, tests, or fixes yourself. Never edit `src/` or `src/tests/`.** All implementation, tests, and code fixes flow through subagents. Your job is to classify work, dispatch the fewest capable specialists, review their summaries, and hold approval gates. If a verification step fails, re-spawn or resume the responsible agent with the compact output — never patch it yourself.
+**Never write production code, tests, or fixes yourself. Never edit `src/` or `src/tests/`.** All implementation, tests, and code fixes flow through subagents. My job is to classify work, dispatch the fewest capable specialists, review their summaries, and hold approval gates. If a verification step fails, I re-spawn or resume the responsible agent with the compact output — I never patch it myself.
 
-## Before you dispatch
+## How I operate
 
-Restate the requirement back in short, plain English first. The user may write Vietnamese or imperfect English — treat it as first-class and never silently pick an interpretation. Confirm before spawning, except for obvious low-complexity tasks. Ask when ambiguous.
-
-Every `AskUserQuestion` option must set `preview` with concrete context for that choice.
-
-## Classify complexity
-
-- **low** — ≤3 files, an existing pattern to follow, no cross-module uncertainty. Docs/config are always low. Auto-confirm.
-- **medium** — genuine design uncertainty: >3 files, no clear pattern, or touch points needing a check before coding. Confirm first.
-- **high** — cross-module/layer, new feature area, or architecture change. Confirm first; implementer runs on sonnet.
-
-When torn between low and medium, start low — the executor reports "bigger than it looked" and you restart as medium.
-
-## Low — lite path (default)
-
-One-line echo (no approval wait) → spawn `direct-executor` with the request verbatim plus scope constraints → review the report. Add `reviewer` only if security-sensitive or the user asks. Nothing commits without the user.
-
-## Medium / High — full pipeline
-
-1. Echo in 2–4 bullets (what changes / what doesn't / before→after) + complexity confirm — one `AskUserQuestion`. Do not spawn the architect before this is confirmed.
-2. Write `workspace/<short-task-description>/requirement.md`.
-3. Spawn `technical-architect` once (it self-researches and nests `investigator`/`wiki-manager` on high). Review its ≤10-line summary only.
-4. **Approval gate:** publish `approval-packet.html` as a rendered Artifact (tabbed Brief / Change Map / Plan / Tests) and print the full `business-brief.md` as the text fallback, then `AskUserQuestion` (Approve / Request Changes). Never skip this for medium/high; never implement before approval.
-5. `implementer` (haiku; `model: "sonnet"` only for high) → `reviewer` → `test-writer` → `documenter`.
-
-## Explain path (how / why / can-I)
-
-Spawn `technical-architect` in `explain` mode → present its `answer.md`. Do not read `src/` or `wiki/` or search code yourself.
-
-## Context budget
-
-Never read `plan.md` / `test-plan.md` / `wiki-brief.md` / `answers-*.md` in full — review the architect's ≤10-line summary. Never paste a subagent's raw exploration into chat — summaries only. Use compact `*:ci` scripts only (`format:ci`, `lint:fix:ci`, `test:ci`, `precommit:ci`, `diff:ci`, `type-check:ci`, `build:local:ci`) and print their output as-is.
-
-## Model policy
-
-Agent frontmatter is the source of truth — never pass `model:` except `implementer` on high (`"sonnet"`). Never upgrade a model unless the user asks or a subagent reports blocked.
-
-## Hard rules
-
-- Never write production code, tests, or fixes yourself.
-- Never spawn `wiki-manager` (gather) or `investigator` directly — the architect nests them. `wiki-manager` (update) is EM-spawnable only on user request or before a release.
-- One architect spawn per cycle. Never skip the business-brief approval for medium/high.
-- Spawn every `Agent` in background mode; within a cycle, run pipeline steps strictly one at a time.
-- Use `.claude/` only — never `.cursor/`. No `Co-Authored-By` in commits. Subagents never run `git commit` / `git push`.
-- Be concise — no yapping; details only when asked.
+- **Echo first.** I restate the request in plain English before spawning. I confirm for medium/high; I auto-confirm obvious low.
+- **Low → lite path.** I spawn `direct-executor` with the request plus scope limits, then review its report.
+- **Medium/High → full pipeline** through `technical-architect`. I **never skip the business-brief approval gate, and never implement before approval.** The policy has the exact steps and the artifacts to publish.
+- **Explain questions → `technical-architect` in explain mode.** I do not read `src/` or search code myself.
+- **I stay lean.** I review each subagent's ≤10-line summary, not its files. I never paste raw exploration into chat. I use the compact `*:ci` scripts only.
+- **Models come from agent frontmatter.** I never pass `model:` except `implementer` on high (`"sonnet"`).
+- **I don't do the specialists' jobs.** No production code or tests from me. I never spawn `wiki-manager` (gather) or `investigator` directly — the architect nests them.
+- **Nothing commits without you.** No `Co-Authored-By`; subagents never run git.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,6 @@
 	},
 	"enabledMcpjsonServers": ["glob-grep"],
 	"includeCoAuthoredBy": false,
-	"advisorModel": "opus",
 	"enabledPlugins": {
 		"ponytail@ponytail": false,
 		"pyright-lsp@claude-plugins-official": false,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
 	},
 	"enabledMcpjsonServers": ["glob-grep"],
 	"includeCoAuthoredBy": false,
+	"advisorModel": "opus",
 	"enabledPlugins": {
 		"ponytail@ponytail": false,
 		"pyright-lsp@claude-plugins-official": false,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,7 @@
 		]
 	},
 	"enabledMcpjsonServers": ["codegraph", "glob-grep", "cli-runner", "read-log", "discord-send", "github-release"],
-	"outputStyle": "default",
+	"outputStyle": "Engineer Manager",
 	"spinnerTipsEnabled": true,
 	"statusLine": {
 		"type": "command",

--- a/.claude/skills/workspace-console/SKILL.md
+++ b/.claude/skills/workspace-console/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: workspace-console
+description: Rebuild and update the Workspace Console artifact from local workspace/ tasks. Appends/updates tasks in a persistent gitignored index, then publishes to the SAME artifact URL so nothing is lost. Use when the user wants to refresh their workspace dashboard, add a task to it, or asks for /workspace-console. Main session only — a subagent cannot publish artifacts.
+---
+
+# Workspace Console
+
+Keep a single tabbed dashboard Artifact in sync with the local `workspace/` task folders — **including gitignored, ephemeral ones**. The artifact is a _render_ of a persistent index, never appended to one task at a time, so re-publishing never drops earlier tasks.
+
+**Main session only.** Only the main session holds the `Artifact` tool; a subagent cannot publish. Do not delegate the publish step.
+
+## Model
+
+- **Source of truth:** `workspace/.console-index.json` — a gitignored, local, append-only index. It survives `finalizer` cleanup of ephemeral `workspace/<task>/` folders, so a task stays on the dashboard even after its folder is deleted.
+- **Renderer:** `scripts/workspace-console.mjs` (committed) turns the index into `workspace/.console.html` (gitignored). It owns all layout — never hand-write the HTML.
+- **Publish target:** the `artifactUrl` field in the index (seeded with the canonical Workspace Console URL). Passing it as `url` updates that artifact **in place** — same link.
+
+## Arguments
+
+- **(none)** → upsert **every** `workspace/*/` task folder into the index, then render + publish.
+- **`<folder>`** (e.g. `/workspace-console todo-task`) → upsert **only** that one folder; every other task already in the index is preserved.
+
+## Steps
+
+1. **Ensure the index exists:** run `node scripts/workspace-console.mjs init` (no-op if it already exists — never clobbers).
+2. **Pick scope:** all `workspace/*/` folders (skip dotfiles and non-directories), or just the folder argument. Ignore the permanent helpers `to_do.md` / `claude_history.md` unless the user asks to include them.
+3. **Distill each in-scope task** by reading whatever exists in the folder (`requirement.md`, `business-brief.md`, `plan.md`, `change-map.md`, `answer.md`, `README.md`, proposals) into one index entry:
+   - `id` — the folder name (stable key; this is what makes it an upsert, not a duplicate).
+   - `title` — short human name.
+   - `status` — one of `done` · `in-progress` · `pending` · `deferred` · `reference`.
+   - `source` — the most representative file path.
+   - `summary` — 1–3 plain sentences.
+   - `keyPoints` — up to ~5 bullets (plain strings).
+   - `changeMapMermaid` — _optional_ raw Mermaid source (no fences) if the task has a `change-map.md`; the renderer wraps it in `<pre class="mermaid">`.
+4. **Upsert into `workspace/.console-index.json`:** replace the entry with the same `id`, or append if new. **Never remove other tasks.** Refresh the top-level `updatedAt` (ISO string). Keep `artifactUrl` as-is.
+5. **Render:** `node scripts/workspace-console.mjs render` → writes `workspace/.console.html`.
+6. **Read** `workspace/.console.html` (you did not author it directly), then **publish** with the `Artifact` tool:
+   - `file_path`: `workspace/.console.html`
+   - `url`: the `artifactUrl` from the index (**required** — omitting it mints a new link and defeats the purpose)
+   - `title`: `Workspace Console — Roborock Plugin` · `favicon`: `🤖` (keep both stable across runs)
+   - `description`: one line, e.g. "Tabbed dashboard of the Roborock plugin workspace tasks."
+7. **Report** the artifact URL and how many tasks it now carries.
+
+## Notes
+
+- **Deleting a task** from the dashboard is deliberate: remove its entry from the index by `id`, then render + publish. Don't do it unless asked.
+- **Cross-machine:** the index is local by default (matches gitignored tasks). To share one dashboard across machines instead, move the index to a committed path (e.g. `.claude/workspace-console.json`) and update `INDEX_PATH` in `scripts/workspace-console.mjs` — but that puts task summaries in git.
+- **Ownership:** updating in place requires being logged into the account that owns the artifact. If the `url` update is ever rejected as not-owned, publish fresh (no `url`), then save the new URL into the index's `artifactUrl`.
+- **Lost URL?** `Artifact` `action: "list"` finds it by title (`Workspace Console — Roborock Plugin`).

--- a/.claude/templates/approval-packet.template.html
+++ b/.claude/templates/approval-packet.template.html
@@ -1,0 +1,171 @@
+<!--
+  Approval Packet template — filled by technical-architect (implement mode).
+  Copy to workspace/<task>/approval-packet.html and replace every <!--{{SLOT_*}}--> marker.
+  The EM publishes the result as an Artifact at the approval gate. Self-contained: no external assets.
+  Slots:
+    {{TASK_TITLE}}     plain task name (also used in <title>)
+    {{COMPLEXITY}}     low | medium | high
+    {{SLOT_BRIEF}}     business-brief.md as HTML (h3 sections + p / ul.keys)
+    {{SLOT_CHANGEMAP}} the <pre class="mermaid">…</pre> block from change-map.md + legend/notes
+    {{SLOT_PLAN}}      Files to Modify/Create as a table + Implementation Steps as ul.keys
+    {{SLOT_TESTS}}     Cases to Cover as ul.keys, or a "no test step" note
+-->
+<title><!--{{TASK_TITLE}}--> — Approval Packet</title>
+<style>
+  :root {
+    --bg: #eef1f5; --surface: #ffffff; --surface-2: #f6f8fb; --ink: #16202b; --ink-soft: #33404e;
+    --muted: #5c6b7a; --border: #dbe2ea; --accent: #0b8f94; --accent-ink: #ffffff;
+    --done-fg: #1a7d4b; --done-bg: #e0f2e6; --pending-fg: #a9640a; --pending-bg: #f7ebd6;
+    --defer-fg: #5a6b7c; --defer-bg: #e7edf3; --info-fg: #2f6fb0; --info-bg: #e2edf8;
+    --shadow: 0 1px 2px rgba(20,32,43,.06), 0 8px 24px rgba(20,32,43,.06);
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0c1219; --surface: #141d28; --surface-2: #101823; --ink: #e7eef5; --ink-soft: #c2cedb;
+      --muted: #8394a4; --border: #223041; --accent: #2bd4d9; --accent-ink: #052226;
+      --done-fg: #48d38c; --done-bg: #123528; --pending-fg: #e6ab48; --pending-bg: #382a13;
+      --defer-fg: #93a3b4; --defer-bg: #1c2833; --info-fg: #6db0ec; --info-bg: #14293c;
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #eef1f5; --surface: #ffffff; --surface-2: #f6f8fb; --ink: #16202b; --ink-soft: #33404e;
+    --muted: #5c6b7a; --border: #dbe2ea; --accent: #0b8f94; --accent-ink: #ffffff;
+    --done-fg: #1a7d4b; --done-bg: #e0f2e6; --pending-fg: #a9640a; --pending-bg: #f7ebd6;
+    --defer-fg: #5a6b7c; --defer-bg: #e7edf3; --info-fg: #2f6fb0; --info-bg: #e2edf8;
+    --shadow: 0 1px 2px rgba(20,32,43,.06), 0 8px 24px rgba(20,32,43,.06);
+  }
+  :root[data-theme="dark"] {
+    --bg: #0c1219; --surface: #141d28; --surface-2: #101823; --ink: #e7eef5; --ink-soft: #c2cedb;
+    --muted: #8394a4; --border: #223041; --accent: #2bd4d9; --accent-ink: #052226;
+    --done-fg: #48d38c; --done-bg: #123528; --pending-fg: #e6ab48; --pending-bg: #382a13;
+    --defer-fg: #93a3b4; --defer-bg: #1c2833; --info-fg: #6db0ec; --info-bg: #14293c;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  .wrap { max-width: 940px; margin: 0 auto; padding: 30px 20px 64px; }
+  header.masthead { display: flex; flex-direction: column; gap: 8px; }
+  .eyebrow { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--accent); font-weight: 600; }
+  h1 { font-size: clamp(21px, 3.2vw, 28px); line-height: 1.15; margin: 0; letter-spacing: -.02em; text-wrap: balance; }
+  .metaline { display: flex; flex-wrap: wrap; gap: 8px 10px; align-items: center; margin: 6px 0 0; }
+  .chip { font-family: var(--mono); font-size: 11.5px; font-weight: 600; letter-spacing: .02em; padding: 3px 9px; border-radius: 999px; border: 1px solid transparent; white-space: nowrap; }
+  .chip.done { color: var(--done-fg); background: var(--done-bg); }
+  .chip.pending { color: var(--pending-fg); background: var(--pending-bg); }
+  .chip.defer { color: var(--defer-fg); background: var(--defer-bg); }
+  .chip.info { color: var(--info-fg); background: var(--info-bg); }
+  .chip.file { color: var(--muted); background: var(--surface-2); border-color: var(--border); }
+
+  .tabbar { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin: 22px 0; overflow-x: auto; scrollbar-width: thin; position: sticky; top: 0; background: var(--bg); z-index: 5; padding-top: 4px; }
+  .tab { appearance: none; border: 0; background: transparent; color: var(--muted); cursor: pointer; font-family: var(--sans); font-size: 13.5px; font-weight: 550; padding: 11px 15px 13px; white-space: nowrap; border-bottom: 2px solid transparent; margin-bottom: -1px; border-radius: 8px 8px 0 0; transition: color .15s, background .15s; }
+  .tab:hover { color: var(--ink-soft); background: var(--surface-2); }
+  .tab[aria-selected="true"] { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .panel { display: none; animation: fade .22s ease; }
+  .panel.active { display: block; }
+  @keyframes fade { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { .panel { animation: none; } }
+
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 22px 24px; box-shadow: var(--shadow); }
+  .card h2 { margin: 0 0 6px; font-size: 18px; letter-spacing: -.015em; text-wrap: balance; }
+  .card h3 { margin: 20px 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); }
+  .card h3:first-child, .card h2:first-child { margin-top: 0; }
+  .card p { margin: 10px 0; color: var(--ink-soft); font-size: 14.5px; }
+  .card p.lede { color: var(--ink); font-size: 15.5px; }
+  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); border: 1px solid var(--border); padding: 1px 5px; border-radius: 5px; color: var(--ink); }
+
+  ul.keys { margin: 8px 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 8px; }
+  ul.keys li { position: relative; padding-left: 20px; font-size: 14.5px; color: var(--ink-soft); }
+  ul.keys li::before { content: ""; position: absolute; left: 3px; top: 9px; width: 6px; height: 6px; border-radius: 2px; background: var(--accent); }
+
+  .tablewrap { overflow-x: auto; margin: 10px 0; border: 1px solid var(--border); border-radius: 10px; }
+  table { border-collapse: collapse; width: 100%; font-size: 13.5px; min-width: 440px; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--surface-2); font-size: 11.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); font-weight: 600; }
+  tr:last-child td { border-bottom: 0; }
+  td code { background: transparent; border: 0; padding: 0; color: var(--accent); }
+
+  .diagram { background: var(--surface-2); border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin: 12px 0; overflow-x: auto; }
+  .diagram pre.mermaid { margin: 0; text-align: center; }
+  .legend { display: flex; flex-wrap: wrap; gap: 6px 14px; margin: 8px 2px 0; font-size: 12px; color: var(--muted); font-family: var(--mono); }
+
+  footer { margin-top: 26px; padding-top: 14px; border-top: 1px solid var(--border); color: var(--muted); font-size: 12.5px; }
+  @media (max-width: 620px) { .card { padding: 18px 16px; } }
+</style>
+
+<div class="wrap">
+  <header class="masthead">
+    <span class="eyebrow">Approval Packet</span>
+    <h1><!--{{TASK_TITLE}}--></h1>
+    <div class="metaline">
+      <span class="chip pending">AWAITING APPROVAL</span>
+      <span class="chip defer">Complexity: <!--{{COMPLEXITY}}--></span>
+    </div>
+  </header>
+
+  <div class="tabbar" role="tablist" aria-label="Approval packet">
+    <button class="tab" role="tab" aria-selected="true" aria-controls="p-brief" id="t-brief">Brief</button>
+    <button class="tab" role="tab" aria-selected="false" aria-controls="p-map" id="t-map" tabindex="-1">Change Map</button>
+    <button class="tab" role="tab" aria-selected="false" aria-controls="p-plan" id="t-plan" tabindex="-1">Plan</button>
+    <button class="tab" role="tab" aria-selected="false" aria-controls="p-tests" id="t-tests" tabindex="-1">Tests</button>
+  </div>
+
+  <section class="panel active" role="tabpanel" id="p-brief" aria-labelledby="t-brief">
+    <div class="card">
+      <!--{{SLOT_BRIEF}}-->
+    </div>
+  </section>
+
+  <section class="panel" role="tabpanel" id="p-map" aria-labelledby="t-map" hidden>
+    <div class="card">
+      <h2>Change Map — before → after</h2>
+      <!--{{SLOT_CHANGEMAP}}-->
+    </div>
+  </section>
+
+  <section class="panel" role="tabpanel" id="p-plan" aria-labelledby="t-plan" hidden>
+    <div class="card">
+      <h2>Plan at a glance</h2>
+      <!--{{SLOT_PLAN}}-->
+    </div>
+  </section>
+
+  <section class="panel" role="tabpanel" id="p-tests" aria-labelledby="t-tests" hidden>
+    <div class="card">
+      <h2>Test plan</h2>
+      <!--{{SLOT_TESTS}}-->
+    </div>
+  </section>
+
+  <footer>Approve or request changes in chat. This packet is a private snapshot of the task folder.</footer>
+</div>
+
+<script>
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.panel'));
+    function select(i) {
+      tabs.forEach(function (t, j) {
+        var on = i === j;
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+        t.tabIndex = on ? 0 : -1;
+        panels[j].classList.toggle('active', on);
+        if (on) { panels[j].removeAttribute('hidden'); } else { panels[j].setAttribute('hidden', ''); }
+      });
+    }
+    tabs.forEach(function (t, i) {
+      t.addEventListener('click', function () { select(i); });
+      t.addEventListener('keydown', function (e) {
+        var n = null;
+        if (e.key === 'ArrowRight') n = (i + 1) % tabs.length;
+        else if (e.key === 'ArrowLeft') n = (i - 1 + tabs.length) % tabs.length;
+        else if (e.key === 'Home') n = 0;
+        else if (e.key === 'End') n = tabs.length - 1;
+        if (n !== null) { e.preventDefault(); select(n); tabs[n].focus(); }
+      });
+    });
+  })();
+</script>

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
 		"apple home"
 	],
 	"scripts": {
-		"precommit": "npm run lint && npm run type-check && npm run dup-check && npm run format:check && npm run test",
+		"precommit": "npm run lint && npm run type-check && npm run dup-check && npm run format:check && npm run doctor && npm run test",
 		"precommit:ci": "node scripts/run-precommit-summary.mjs",
+		"doctor": "node scripts/orchestration-doctor.mjs",
+		"doctor:ci": "node scripts/orchestration-doctor.mjs",
 		"precondition": "npm install -g matterbridge@3.10.0",
 		"build:local": "npm run deepClean && npm install && npm link matterbridge && npm run build && npm run matterbridge:add",
 		"build:local:ci": "node scripts/run-build-local-summary.mjs",

--- a/scripts/orchestration-doctor.mjs
+++ b/scripts/orchestration-doctor.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+/* eslint-disable no-console, n/no-process-exit */
 // Orchestration doctor — a fast health check for the .claude/ orchestration setup.
 //
 // Catches the silent breakage that hurts most: a skill/agent/style with missing
@@ -8,7 +8,7 @@
 //
 // Usage: node scripts/orchestration-doctor.mjs
 
-import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 const problems = [];

--- a/scripts/orchestration-doctor.mjs
+++ b/scripts/orchestration-doctor.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Orchestration doctor — a fast health check for the .claude/ orchestration setup.
+//
+// Catches the silent breakage that hurts most: a skill/agent/style with missing
+// frontmatter, or a `.claude/...` / `scripts/...` file reference that no longer resolves
+// (e.g. a renamed script or template). Prints a compact PASS line or a list of problems,
+// and exits non-zero on any problem so it can gate a precommit run.
+//
+// Usage: node scripts/orchestration-doctor.mjs
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const problems = [];
+const stats = { agents: 0, skills: 0, styles: 0, refs: 0 };
+
+function walk(dir) {
+	const out = [];
+	if (!existsSync(dir)) return out;
+	for (const name of readdirSync(dir)) {
+		const p = join(dir, name);
+		const s = statSync(p);
+		if (s.isDirectory()) out.push(...walk(p));
+		else if (name.endsWith('.md')) out.push(p);
+	}
+	return out;
+}
+
+/** Return the YAML frontmatter block text, or null if absent. */
+function frontmatter(text) {
+	if (!text.startsWith('---')) return null;
+	const end = text.indexOf('\n---', 3);
+	return end === -1 ? null : text.slice(3, end);
+}
+
+function checkFrontmatter(file, kind) {
+	const fm = frontmatter(readFileSync(file, 'utf8'));
+	if (!fm) {
+		problems.push(`${kind}: ${file} — missing YAML frontmatter (--- block)`);
+		return;
+	}
+	if (!/^\s*name\s*:/m.test(fm)) problems.push(`${kind}: ${file} — frontmatter missing "name"`);
+	if (!/^\s*description\s*:/m.test(fm)) problems.push(`${kind}: ${file} — frontmatter missing "description"`);
+}
+
+// 1. Agents — .claude/agents/*.md
+for (const f of walk('.claude/agents')) {
+	stats.agents++;
+	checkFrontmatter(f, 'agent');
+}
+
+// 2. Output styles — .claude/output-styles/*.md
+for (const f of walk('.claude/output-styles')) {
+	stats.styles++;
+	checkFrontmatter(f, 'style');
+}
+
+// 3. Skills — .claude/skills/<name>/SKILL.md, folder name should match frontmatter name
+for (const dir of existsSync('.claude/skills') ? readdirSync('.claude/skills') : []) {
+	const skillFile = join('.claude/skills', dir, 'SKILL.md');
+	if (!existsSync(skillFile)) continue;
+	stats.skills++;
+	checkFrontmatter(skillFile, 'skill');
+	const fm = frontmatter(readFileSync(skillFile, 'utf8')) || '';
+	const m = fm.match(/^\s*name\s*:\s*(.+?)\s*$/m);
+	if (m && m[1].trim() !== dir) {
+		problems.push(`skill: ${skillFile} — folder "${dir}" != frontmatter name "${m[1].trim()}"`);
+	}
+}
+
+// 4. Broken references — backtick-quoted `.claude/...` and `scripts/...` paths that don't resolve.
+//    Conservative: only committed orchestration paths, only clear file extensions, skip
+//    placeholders (<>, *, ...) and generated/ephemeral paths (workspace/, dist/).
+const REF = /`((?:\.claude|scripts)\/[^`]+?)`/g;
+const EXT = /\.(md|html|json|mjs|cjs|js|ts|sh)$/;
+// Lines that present a path as a hypothetical/example are not real references.
+const EXAMPLE_LINE = /\b(e\.g\.|example|instead|such as|would be|could be)\b/i;
+const seen = new Set();
+for (const f of walk('.claude')) {
+	const text = readFileSync(f, 'utf8');
+	const lines = text.split('\n');
+	for (const line of lines) {
+		if (EXAMPLE_LINE.test(line)) continue;
+		let m;
+		REF.lastIndex = 0;
+		while ((m = REF.exec(line)) !== null) {
+			const ref = m[1];
+			if (/[<>*]|\.\.\./.test(ref) || ref.includes(' ') || !EXT.test(ref)) continue;
+			if (seen.has(ref)) continue;
+			seen.add(ref);
+			stats.refs++;
+			if (!existsSync(ref)) problems.push(`ref: ${f} points to missing "${ref}"`);
+		}
+	}
+}
+
+if (problems.length) {
+	console.log(`DOCTOR: ${problems.length} problem(s)`);
+	for (const p of problems) console.log(`  - ${p}`);
+	process.exit(1);
+}
+console.log(
+	`DOCTOR: ok (${stats.agents} agents, ${stats.styles} styles, ${stats.skills} skills, ${stats.refs} refs checked)`,
+);

--- a/scripts/workspace-console.mjs
+++ b/scripts/workspace-console.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+// Workspace Console renderer.
+//
+// The Workspace Console artifact is a *render* of a persistent task index, not a
+// place tasks are appended to one at a time. The index (workspace/.console-index.json)
+// is the source of truth; this script turns it into a self-contained tabbed HTML page
+// (workspace/.console.html) that the /workspace-console skill publishes as an Artifact.
+//
+// Both files live under workspace/ and are gitignored (workspace/* ignore rule) — the
+// index accumulates locally and survives finalizer cleanup of ephemeral task folders.
+//
+// Usage:
+//   node scripts/workspace-console.mjs init     # create an empty index (keeps existing)
+//   node scripts/workspace-console.mjs render    # index -> workspace/.console.html
+//   node scripts/workspace-console.mjs           # same as render
+//
+// The canonical artifact URL lives in the index (`artifactUrl`); `init` seeds it with
+// DEFAULT_ARTIFACT_URL so a fresh machine updates the same artifact in place.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const DEFAULT_ARTIFACT_URL = 'https://claude.ai/code/artifact/6425695a-b0e4-4719-8cf8-9ff31fc2c2e6';
+const INDEX_PATH = resolve('workspace/.console-index.json');
+const OUT_PATH = resolve('workspace/.console.html');
+
+/** @typedef {{id:string,title:string,status:string,source?:string,summary?:string,keyPoints?:string[],changeMapMermaid?:string,updatedAt?:string}} Task */
+
+const STATUS = {
+  done: { cls: 'done', label: 'Done' },
+  'in-progress': { cls: 'active', label: 'In progress' },
+  pending: { cls: 'pending', label: 'Pending' },
+  deferred: { cls: 'defer', label: 'Deferred' },
+  reference: { cls: 'info', label: 'Reference' },
+};
+const statusInfo = (s) => STATUS[s] || { cls: 'defer', label: s || 'Unknown' };
+
+const esc = (v) =>
+  String(v ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+// Mermaid source must keep its `>` arrows; only neutralize the HTML-breaking chars.
+const escMermaid = (v) => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;');
+
+function loadIndex() {
+  if (!existsSync(INDEX_PATH)) {
+    throw new Error(`No index at ${INDEX_PATH}. Run "node scripts/workspace-console.mjs init" first.`);
+  }
+  const idx = JSON.parse(readFileSync(INDEX_PATH, 'utf8'));
+  idx.tasks = Array.isArray(idx.tasks) ? idx.tasks : [];
+  idx.artifactUrl = idx.artifactUrl || DEFAULT_ARTIFACT_URL;
+  return idx;
+}
+
+function init() {
+  if (existsSync(INDEX_PATH)) {
+    console.log(`Index already exists at ${INDEX_PATH} — left untouched.`);
+    return;
+  }
+  mkdirSync(dirname(INDEX_PATH), { recursive: true });
+  const seed = { artifactUrl: DEFAULT_ARTIFACT_URL, updatedAt: new Date().toISOString(), tasks: [] };
+  writeFileSync(INDEX_PATH, JSON.stringify(seed, null, 2) + '\n');
+  console.log(`Created ${INDEX_PATH}`);
+}
+
+function renderKeyPoints(points) {
+  if (!Array.isArray(points) || points.length === 0) return '';
+  return `<ul class="keys">${points.map((p) => `<li>${esc(p)}</li>`).join('')}</ul>`;
+}
+
+function renderChangeMap(mermaid) {
+  if (!mermaid) return '';
+  return `<div class="diagram"><pre class="mermaid">\n${escMermaid(mermaid)}\n</pre></div>`;
+}
+
+function renderTaskPanel(task, i) {
+  const st = statusInfo(task.status);
+  const meta = [
+    `<span class="chip ${st.cls}">${esc(st.label).toUpperCase()}</span>`,
+    task.source ? `<span class="chip file">${esc(task.source)}</span>` : '',
+  ].join('');
+  return `  <section class="panel${i === 0 ? ' active' : ''}" role="tabpanel" id="p-${i}" aria-labelledby="t-${i}"${i === 0 ? '' : ' hidden'}>
+    <div class="card">
+      <h2>${esc(task.title || task.id)}</h2>
+      <div class="metaline">${meta}</div>
+      ${task.summary ? `<p class="lede">${esc(task.summary)}</p>` : ''}
+      ${renderChangeMap(task.changeMapMermaid)}
+      ${renderKeyPoints(task.keyPoints)}
+    </div>
+  </section>`;
+}
+
+function renderTab(task, i) {
+  const st = statusInfo(task.status);
+  return `    <button class="tab" role="tab" aria-selected="${i === 0}" aria-controls="p-${i}" id="t-${i}"${i === 0 ? '' : ' tabindex="-1"'}><span class="dot ${st.cls}"></span>${esc(task.title || task.id)}</button>`;
+}
+
+function renderOverview(tasks) {
+  const rows = tasks
+    .map((t) => {
+      const st = statusInfo(t.status);
+      return `<li><span class="chip ${st.cls}">${esc(st.label)}</span><span>${esc(t.title || t.id)}${t.summary ? ` — <span class="ov-sum">${esc(t.summary)}</span>` : ''}</span></li>`;
+    })
+    .join('');
+  return `<ul class="overview">${rows || '<li><span>No tasks in the index yet.</span></li>'}</ul>`;
+}
+
+function render() {
+  const idx = loadIndex();
+  const tasks = idx.tasks;
+  const counts = { done: 0, pending: 0, deferred: 0 };
+  for (const t of tasks) {
+    if (t.status === 'done') counts.done++;
+    else if (t.status === 'pending' || t.status === 'in-progress') counts.pending++;
+    else counts.deferred++;
+  }
+
+  // Overview is tab 0; tasks follow.
+  const tabs = [
+    `    <button class="tab" role="tab" aria-selected="true" aria-controls="p-0" id="t-0"><span class="dot"></span>Overview</button>`,
+    ...tasks.map((t, i) => renderTab(t, i + 1)),
+  ].join('\n');
+
+  const panels = [
+    `  <section class="panel active" role="tabpanel" id="p-0" aria-labelledby="t-0">
+    <div class="card">
+      <h2>Workspace overview</h2>
+      <p>${tasks.length} task${tasks.length === 1 ? '' : 's'} tracked in the local index. Each has its own tab.</p>
+      ${renderOverview(tasks)}
+    </div>
+  </section>`,
+    ...tasks.map((t, i) => renderTaskPanel(t, i + 1)),
+  ].join('\n');
+
+  const updated = idx.updatedAt ? new Date(idx.updatedAt) : new Date();
+  const updatedStr = updated.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';
+
+  const html = `<title>Workspace Console — Roborock Plugin</title>
+<style>
+  :root {
+    --bg:#eef1f5; --surface:#fff; --surface-2:#f6f8fb; --ink:#16202b; --ink-soft:#33404e; --muted:#5c6b7a;
+    --border:#dbe2ea; --accent:#0b8f94; --done-fg:#1a7d4b; --done-bg:#e0f2e6; --active-fg:#0b6d71; --active-bg:#d7efef;
+    --pending-fg:#a9640a; --pending-bg:#f7ebd6; --defer-fg:#5a6b7c; --defer-bg:#e7edf3; --info-fg:#2f6fb0; --info-bg:#e2edf8;
+    --shadow:0 1px 2px rgba(20,32,43,.06),0 8px 24px rgba(20,32,43,.06);
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0c1219; --surface:#141d28; --surface-2:#101823; --ink:#e7eef5; --ink-soft:#c2cedb; --muted:#8394a4;
+    --border:#223041; --accent:#2bd4d9; --done-fg:#48d38c; --done-bg:#123528; --active-fg:#2bd4d9; --active-bg:#123138;
+    --pending-fg:#e6ab48; --pending-bg:#382a13; --defer-fg:#93a3b4; --defer-bg:#1c2833; --info-fg:#6db0ec; --info-bg:#14293c;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.35);
+  }}
+  :root[data-theme="light"]{
+    --bg:#eef1f5; --surface:#fff; --surface-2:#f6f8fb; --ink:#16202b; --ink-soft:#33404e; --muted:#5c6b7a;
+    --border:#dbe2ea; --accent:#0b8f94; --done-fg:#1a7d4b; --done-bg:#e0f2e6; --active-fg:#0b6d71; --active-bg:#d7efef;
+    --pending-fg:#a9640a; --pending-bg:#f7ebd6; --defer-fg:#5a6b7c; --defer-bg:#e7edf3; --info-fg:#2f6fb0; --info-bg:#e2edf8;
+    --shadow:0 1px 2px rgba(20,32,43,.06),0 8px 24px rgba(20,32,43,.06);
+  }
+  :root[data-theme="dark"]{
+    --bg:#0c1219; --surface:#141d28; --surface-2:#101823; --ink:#e7eef5; --ink-soft:#c2cedb; --muted:#8394a4;
+    --border:#223041; --accent:#2bd4d9; --done-fg:#48d38c; --done-bg:#123528; --active-fg:#2bd4d9; --active-bg:#123138;
+    --pending-fg:#e6ab48; --pending-bg:#382a13; --defer-fg:#93a3b4; --defer-bg:#1c2833; --info-fg:#6db0ec; --info-bg:#14293c;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.35);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1020px;margin:0 auto;padding:30px 20px 64px}
+  .eyebrow{font-family:var(--mono);font-size:11.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);font-weight:600}
+  h1{font-size:clamp(21px,3.2vw,28px);line-height:1.15;margin:6px 0 0;letter-spacing:-.02em;text-wrap:balance}
+  .sub{color:var(--muted);font-size:13px;margin:6px 0 0;font-family:var(--mono)}
+  .stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin:24px 0 20px}
+  .stat{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:3px}
+  .stat .n{font-family:var(--mono);font-size:26px;font-weight:600;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+  .stat .l{font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.05em}
+  .stat.done .n{color:var(--done-fg)} .stat.pending .n{color:var(--pending-fg)} .stat.defer .n{color:var(--defer-fg)} .stat.total .n{color:var(--accent)}
+  .tabbar{display:flex;gap:4px;border-bottom:1px solid var(--border);margin-bottom:22px;overflow-x:auto;scrollbar-width:thin;position:sticky;top:0;background:var(--bg);z-index:5;padding-top:4px}
+  .tab{appearance:none;border:0;background:transparent;color:var(--muted);cursor:pointer;font-family:var(--sans);font-size:13.5px;font-weight:550;padding:11px 15px 13px;white-space:nowrap;border-bottom:2px solid transparent;margin-bottom:-1px;border-radius:8px 8px 0 0;transition:color .15s,background .15s;display:inline-flex;align-items:center;gap:8px}
+  .tab:hover{color:var(--ink-soft);background:var(--surface-2)}
+  .tab[aria-selected="true"]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tab:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .tab .dot{width:7px;height:7px;border-radius:50%;background:var(--muted)}
+  .tab .dot.done{background:var(--done-fg)} .tab .dot.pending{background:var(--pending-fg)} .tab .dot.active{background:var(--active-fg)} .tab .dot.defer{background:var(--defer-fg)} .tab .dot.info{background:var(--info-fg)}
+  .panel{display:none;animation:fade .22s ease}
+  .panel.active{display:block}
+  @keyframes fade{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  @media (prefers-reduced-motion:reduce){.panel{animation:none}}
+  .card{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:22px 24px;box-shadow:var(--shadow)}
+  .card h2{margin:0 0 6px;font-size:18px;letter-spacing:-.015em;text-wrap:balance}
+  .card p{margin:10px 0;color:var(--ink-soft);font-size:14.5px}
+  .card p.lede{color:var(--ink);font-size:15.5px}
+  .metaline{display:flex;flex-wrap:wrap;gap:8px 10px;align-items:center;margin:8px 0 2px}
+  .chip{font-family:var(--mono);font-size:11.5px;font-weight:600;letter-spacing:.02em;padding:3px 9px;border-radius:999px;border:1px solid transparent;white-space:nowrap}
+  .chip.done{color:var(--done-fg);background:var(--done-bg)} .chip.active{color:var(--active-fg);background:var(--active-bg)} .chip.pending{color:var(--pending-fg);background:var(--pending-bg)} .chip.defer{color:var(--defer-fg);background:var(--defer-bg)} .chip.info{color:var(--info-fg);background:var(--info-bg)}
+  .chip.file{color:var(--muted);background:var(--surface-2);border-color:var(--border)}
+  ul.keys{margin:8px 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:8px}
+  ul.keys li{position:relative;padding-left:20px;font-size:14.5px;color:var(--ink-soft)}
+  ul.keys li::before{content:"";position:absolute;left:3px;top:9px;width:6px;height:6px;border-radius:2px;background:var(--accent)}
+  ul.overview{margin:10px 0 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:8px}
+  ul.overview li{display:flex;gap:11px;align-items:baseline;padding:9px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:9px;font-size:14px}
+  ul.overview .ov-sum{color:var(--muted)}
+  .diagram{background:var(--surface-2);border:1px solid var(--border);border-radius:12px;padding:14px;margin:12px 0;overflow-x:auto}
+  .diagram pre.mermaid{margin:0;text-align:center}
+  footer{margin-top:26px;padding-top:14px;border-top:1px solid var(--border);color:var(--muted);font-size:12.5px;display:flex;flex-wrap:wrap;gap:6px 14px;justify-content:space-between}
+  @media (max-width:640px){.stats{grid-template-columns:repeat(2,1fr)}.card{padding:18px 16px}}
+</style>
+
+<div class="wrap">
+  <header>
+    <span class="eyebrow">Workspace Console</span>
+    <h1>Matterbridge · Roborock Vacuum Plugin</h1>
+    <p class="sub">Rendered from the local task index · updated ${esc(updatedStr)}</p>
+  </header>
+
+  <section class="stats" aria-label="Workspace summary">
+    <div class="stat total"><span class="n">${tasks.length}</span><span class="l">Tasks</span></div>
+    <div class="stat done"><span class="n">${counts.done}</span><span class="l">Done</span></div>
+    <div class="stat pending"><span class="n">${counts.pending}</span><span class="l">Active / Pending</span></div>
+    <div class="stat defer"><span class="n">${counts.deferred}</span><span class="l">Deferred / Ref</span></div>
+  </section>
+
+  <div class="tabbar" role="tablist" aria-label="Workspace tasks">
+${tabs}
+  </div>
+
+${panels}
+
+  <footer>
+    <span>Generated from <code>workspace/</code> — snapshot, private by default.</span>
+    <span>${counts.done} done · ${counts.pending} active/pending · ${counts.deferred} deferred</span>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.panel'));
+    function select(i) {
+      tabs.forEach(function (t, j) {
+        var on = i === j;
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+        t.tabIndex = on ? 0 : -1;
+        panels[j].classList.toggle('active', on);
+        if (on) { panels[j].removeAttribute('hidden'); } else { panels[j].setAttribute('hidden', ''); }
+      });
+    }
+    tabs.forEach(function (t, i) {
+      t.addEventListener('click', function () { select(i); });
+      t.addEventListener('keydown', function (e) {
+        var n = null;
+        if (e.key === 'ArrowRight') n = (i + 1) % tabs.length;
+        else if (e.key === 'ArrowLeft') n = (i - 1 + tabs.length) % tabs.length;
+        else if (e.key === 'Home') n = 0;
+        else if (e.key === 'End') n = tabs.length - 1;
+        if (n !== null) { e.preventDefault(); select(n); tabs[n].focus(); }
+      });
+    });
+  })();
+</script>
+`;
+
+  writeFileSync(OUT_PATH, html);
+  console.log(`Rendered ${tasks.length} task(s) -> ${OUT_PATH}`);
+  console.log(`Artifact URL (publish target): ${idx.artifactUrl}`);
+}
+
+const cmd = process.argv[2] || 'render';
+if (cmd === 'init') init();
+else if (cmd === 'render') render();
+else {
+  console.error(`Unknown command "${cmd}". Use: init | render`);
+  process.exit(1);
+}

--- a/scripts/workspace-console.mjs
+++ b/scripts/workspace-console.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+/* eslint-disable no-console, n/no-process-exit */
 // Workspace Console renderer.
 //
 // The Workspace Console artifact is a *render* of a persistent task index, not a
@@ -17,7 +17,7 @@
 // The canonical artifact URL lives in the index (`artifactUrl`); `init` seeds it with
 // DEFAULT_ARTIFACT_URL so a fresh machine updates the same artifact in place.
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 const DEFAULT_ARTIFACT_URL = 'https://claude.ai/code/artifact/6425695a-b0e4-4719-8cf8-9ff31fc2c2e6';
@@ -27,62 +27,65 @@ const OUT_PATH = resolve('workspace/.console.html');
 /** @typedef {{id:string,title:string,status:string,source?:string,summary?:string,keyPoints?:string[],changeMapMermaid?:string,updatedAt?:string}} Task */
 
 const STATUS = {
-  done: { cls: 'done', label: 'Done' },
-  'in-progress': { cls: 'active', label: 'In progress' },
-  pending: { cls: 'pending', label: 'Pending' },
-  deferred: { cls: 'defer', label: 'Deferred' },
-  reference: { cls: 'info', label: 'Reference' },
+	done: { cls: 'done', label: 'Done' },
+	'in-progress': { cls: 'active', label: 'In progress' },
+	pending: { cls: 'pending', label: 'Pending' },
+	deferred: { cls: 'defer', label: 'Deferred' },
+	reference: { cls: 'info', label: 'Reference' },
 };
 const statusInfo = (s) => STATUS[s] || { cls: 'defer', label: s || 'Unknown' };
 
 const esc = (v) =>
-  String(v ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+	String(v ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
 
 // Mermaid source must keep its `>` arrows; only neutralize the HTML-breaking chars.
-const escMermaid = (v) => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;');
+const escMermaid = (v) =>
+	String(v ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;');
 
 function loadIndex() {
-  if (!existsSync(INDEX_PATH)) {
-    throw new Error(`No index at ${INDEX_PATH}. Run "node scripts/workspace-console.mjs init" first.`);
-  }
-  const idx = JSON.parse(readFileSync(INDEX_PATH, 'utf8'));
-  idx.tasks = Array.isArray(idx.tasks) ? idx.tasks : [];
-  idx.artifactUrl = idx.artifactUrl || DEFAULT_ARTIFACT_URL;
-  return idx;
+	if (!existsSync(INDEX_PATH)) {
+		throw new Error(`No index at ${INDEX_PATH}. Run "node scripts/workspace-console.mjs init" first.`);
+	}
+	const idx = JSON.parse(readFileSync(INDEX_PATH, 'utf8'));
+	idx.tasks = Array.isArray(idx.tasks) ? idx.tasks : [];
+	idx.artifactUrl = idx.artifactUrl || DEFAULT_ARTIFACT_URL;
+	return idx;
 }
 
 function init() {
-  if (existsSync(INDEX_PATH)) {
-    console.log(`Index already exists at ${INDEX_PATH} — left untouched.`);
-    return;
-  }
-  mkdirSync(dirname(INDEX_PATH), { recursive: true });
-  const seed = { artifactUrl: DEFAULT_ARTIFACT_URL, updatedAt: new Date().toISOString(), tasks: [] };
-  writeFileSync(INDEX_PATH, JSON.stringify(seed, null, 2) + '\n');
-  console.log(`Created ${INDEX_PATH}`);
+	if (existsSync(INDEX_PATH)) {
+		console.log(`Index already exists at ${INDEX_PATH} — left untouched.`);
+		return;
+	}
+	mkdirSync(dirname(INDEX_PATH), { recursive: true });
+	const seed = { artifactUrl: DEFAULT_ARTIFACT_URL, updatedAt: new Date().toISOString(), tasks: [] };
+	writeFileSync(INDEX_PATH, JSON.stringify(seed, null, 2) + '\n');
+	console.log(`Created ${INDEX_PATH}`);
 }
 
 function renderKeyPoints(points) {
-  if (!Array.isArray(points) || points.length === 0) return '';
-  return `<ul class="keys">${points.map((p) => `<li>${esc(p)}</li>`).join('')}</ul>`;
+	if (!Array.isArray(points) || points.length === 0) return '';
+	return `<ul class="keys">${points.map((p) => `<li>${esc(p)}</li>`).join('')}</ul>`;
 }
 
 function renderChangeMap(mermaid) {
-  if (!mermaid) return '';
-  return `<div class="diagram"><pre class="mermaid">\n${escMermaid(mermaid)}\n</pre></div>`;
+	if (!mermaid) return '';
+	return `<div class="diagram"><pre class="mermaid">\n${escMermaid(mermaid)}\n</pre></div>`;
 }
 
 function renderTaskPanel(task, i) {
-  const st = statusInfo(task.status);
-  const meta = [
-    `<span class="chip ${st.cls}">${esc(st.label).toUpperCase()}</span>`,
-    task.source ? `<span class="chip file">${esc(task.source)}</span>` : '',
-  ].join('');
-  return `  <section class="panel${i === 0 ? ' active' : ''}" role="tabpanel" id="p-${i}" aria-labelledby="t-${i}"${i === 0 ? '' : ' hidden'}>
+	const st = statusInfo(task.status);
+	const meta = [
+		`<span class="chip ${st.cls}">${esc(st.label).toUpperCase()}</span>`,
+		task.source ? `<span class="chip file">${esc(task.source)}</span>` : '',
+	].join('');
+	return `  <section class="panel${i === 0 ? ' active' : ''}" role="tabpanel" id="p-${i}" aria-labelledby="t-${i}"${i === 0 ? '' : ' hidden'}>
     <div class="card">
       <h2>${esc(task.title || task.id)}</h2>
       <div class="metaline">${meta}</div>
@@ -94,51 +97,51 @@ function renderTaskPanel(task, i) {
 }
 
 function renderTab(task, i) {
-  const st = statusInfo(task.status);
-  return `    <button class="tab" role="tab" aria-selected="${i === 0}" aria-controls="p-${i}" id="t-${i}"${i === 0 ? '' : ' tabindex="-1"'}><span class="dot ${st.cls}"></span>${esc(task.title || task.id)}</button>`;
+	const st = statusInfo(task.status);
+	return `    <button class="tab" role="tab" aria-selected="${i === 0}" aria-controls="p-${i}" id="t-${i}"${i === 0 ? '' : ' tabindex="-1"'}><span class="dot ${st.cls}"></span>${esc(task.title || task.id)}</button>`;
 }
 
 function renderOverview(tasks) {
-  const rows = tasks
-    .map((t) => {
-      const st = statusInfo(t.status);
-      return `<li><span class="chip ${st.cls}">${esc(st.label)}</span><span>${esc(t.title || t.id)}${t.summary ? ` — <span class="ov-sum">${esc(t.summary)}</span>` : ''}</span></li>`;
-    })
-    .join('');
-  return `<ul class="overview">${rows || '<li><span>No tasks in the index yet.</span></li>'}</ul>`;
+	const rows = tasks
+		.map((t) => {
+			const st = statusInfo(t.status);
+			return `<li><span class="chip ${st.cls}">${esc(st.label)}</span><span>${esc(t.title || t.id)}${t.summary ? ` — <span class="ov-sum">${esc(t.summary)}</span>` : ''}</span></li>`;
+		})
+		.join('');
+	return `<ul class="overview">${rows || '<li><span>No tasks in the index yet.</span></li>'}</ul>`;
 }
 
 function render() {
-  const idx = loadIndex();
-  const tasks = idx.tasks;
-  const counts = { done: 0, pending: 0, deferred: 0 };
-  for (const t of tasks) {
-    if (t.status === 'done') counts.done++;
-    else if (t.status === 'pending' || t.status === 'in-progress') counts.pending++;
-    else counts.deferred++;
-  }
+	const idx = loadIndex();
+	const tasks = idx.tasks;
+	const counts = { done: 0, pending: 0, deferred: 0 };
+	for (const t of tasks) {
+		if (t.status === 'done') counts.done++;
+		else if (t.status === 'pending' || t.status === 'in-progress') counts.pending++;
+		else counts.deferred++;
+	}
 
-  // Overview is tab 0; tasks follow.
-  const tabs = [
-    `    <button class="tab" role="tab" aria-selected="true" aria-controls="p-0" id="t-0"><span class="dot"></span>Overview</button>`,
-    ...tasks.map((t, i) => renderTab(t, i + 1)),
-  ].join('\n');
+	// Overview is tab 0; tasks follow.
+	const tabs = [
+		`    <button class="tab" role="tab" aria-selected="true" aria-controls="p-0" id="t-0"><span class="dot"></span>Overview</button>`,
+		...tasks.map((t, i) => renderTab(t, i + 1)),
+	].join('\n');
 
-  const panels = [
-    `  <section class="panel active" role="tabpanel" id="p-0" aria-labelledby="t-0">
+	const panels = [
+		`  <section class="panel active" role="tabpanel" id="p-0" aria-labelledby="t-0">
     <div class="card">
       <h2>Workspace overview</h2>
       <p>${tasks.length} task${tasks.length === 1 ? '' : 's'} tracked in the local index. Each has its own tab.</p>
       ${renderOverview(tasks)}
     </div>
   </section>`,
-    ...tasks.map((t, i) => renderTaskPanel(t, i + 1)),
-  ].join('\n');
+		...tasks.map((t, i) => renderTaskPanel(t, i + 1)),
+	].join('\n');
 
-  const updated = idx.updatedAt ? new Date(idx.updatedAt) : new Date();
-  const updatedStr = updated.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';
+	const updated = idx.updatedAt ? new Date(idx.updatedAt) : new Date();
+	const updatedStr = updated.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';
 
-  const html = `<title>Workspace Console — Roborock Plugin</title>
+	const html = `<title>Workspace Console — Roborock Plugin</title>
 <style>
   :root {
     --bg:#eef1f5; --surface:#fff; --surface-2:#f6f8fb; --ink:#16202b; --ink-soft:#33404e; --muted:#5c6b7a;
@@ -262,15 +265,15 @@ ${panels}
 </script>
 `;
 
-  writeFileSync(OUT_PATH, html);
-  console.log(`Rendered ${tasks.length} task(s) -> ${OUT_PATH}`);
-  console.log(`Artifact URL (publish target): ${idx.artifactUrl}`);
+	writeFileSync(OUT_PATH, html);
+	console.log(`Rendered ${tasks.length} task(s) -> ${OUT_PATH}`);
+	console.log(`Artifact URL (publish target): ${idx.artifactUrl}`);
 }
 
 const cmd = process.argv[2] || 'render';
 if (cmd === 'init') init();
 else if (cmd === 'render') render();
 else {
-  console.error(`Unknown command "${cmd}". Use: init | render`);
-  process.exit(1);
+	console.error(`Unknown command "${cmd}". Use: init | render`);
+	process.exit(1);
 }


### PR DESCRIPTION
## Summary

Four orchestration/config improvements under `.claude/`. No production code (`src/`) or tests are touched.

## Changes

1. **`advisorModel: "opus"`** in `.claude/settings.json` — enables Claude Code's advisor tool. `opus` is the only advisor that satisfies every tier in the team (Haiku, Sonnet, and the Opus main session), since the advisor must be at least as capable as each agent's own model.

2. **Engineer Manager output style** (`.claude/output-styles/engineer-manager.md`) — encodes the EM orchestrator identity (dispatch subagents, never write code directly, echo-first, complexity gating, approval gates) at the system-prompt level. Opt-in via `/output-style`; points to `team-orchestrator-policy.md` as the source of truth so the two can't drift. Shapes the main session only — subagents keep their own definitions.

3. **Change-map before → after diagram** — the Technical Architect now produces `change-map.md` (a delta-annotated Mermaid diagram: new / changed / removed) alongside `plan.md` and `business-brief.md`. The reviewer verifies the diagram matches `plan.md`. Gated to medium/high tasks.

4. **Tabbed approval packet at the gate** — a checked-in template (`.claude/templates/approval-packet.template.html`, self-contained, theme-aware, renders Mermaid natively) that the TA fills into `workspace/<task>/approval-packet.html` (new Step 6d). The approval gate publishes that single tabbed Artifact — **Brief · Change Map · Plan · Tests** — so the change can be reviewed at a glance before deciding, superseding the standalone change-map publish. `business-brief.md` is still printed in chat as the text fallback.

## Files

- `.claude/settings.json`
- `.claude/output-styles/engineer-manager.md` *(new)*
- `.claude/templates/approval-packet.template.html` *(new)*
- `.claude/agents/technical-architect.md`
- `.claude/agents/reviewer.md`
- `.claude/instructions/team-orchestrator-policy.md`

## Verification

`format:ci` passing across all changes. Docs/config only — no `src/` or test changes.

https://claude.ai/code/session_019tuYY9fncxheJrfqVt2c2r

---
_Generated by [Claude Code](https://claude.ai/code/session_019tuYY9fncxheJrfqVt2c2r)_